### PR TITLE
Avoid allocating RowDimension when the row is visible by default

### DIFF
--- a/src/PhpSpreadsheet/Worksheet/AutoFilter.php
+++ b/src/PhpSpreadsheet/Worksheet/AutoFilter.php
@@ -1049,7 +1049,11 @@ class AutoFilter
                 }
             }
             //    Set show/hide for the row based on the result of the autoFilter result
-            $this->workSheet->getRowDimension((int) $row)->setVisible($result);
+            //    If the RowDimension object has not been allocated yet and the row should be visible,
+            //    then we can avoid any operation since the rows are visible by default (saves a lot of memory)
+            if ($this->workSheet->rowDimensionExists((int) $row) || $result === false) {
+                $this->workSheet->getRowDimension((int) $row)->setVisible($result);
+            }
         }
         $this->evaluated = true;
 

--- a/tests/PhpSpreadsheetTests/Calculation/ArrayFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/ArrayFormulaTest.php
@@ -19,7 +19,7 @@ class ArrayFormulaTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerArrayFormulae(): array
+    public static function providerArrayFormulae(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Calculation/BinaryComparisonTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/BinaryComparisonTest.php
@@ -47,7 +47,7 @@ class BinaryComparisonTest extends TestCase
         self::assertEquals($expectedResultOpenOffice, $resultOpenOffice, 'should be OpenOffice compatible');
     }
 
-    public function providerBinaryComparison(): array
+    public static function providerBinaryComparison(): array
     {
         return require 'tests/data/Calculation/BinaryComparisonOperations.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationFunctionListTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationFunctionListTest.php
@@ -46,7 +46,7 @@ class CalculationFunctionListTest extends TestCase
         self::assertIsCallable($functionCall);
     }
 
-    public function providerGetFunctions(): array
+    public static function providerGetFunctions(): array
     {
         return Calculation::getInstance()->getFunctions();
     }

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationSettingsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationSettingsTest.php
@@ -50,7 +50,7 @@ class CalculationSettingsTest extends TestCase
         self::assertFalse($calculation->setLocale('xx'));
     }
 
-    public function providerCanLoadAllSupportedLocales(): array
+    public static function providerCanLoadAllSupportedLocales(): array
     {
         return [
             ['bg'],

--- a/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/CalculationTest.php
@@ -54,7 +54,7 @@ class CalculationTest extends TestCase
         self::assertEquals($expectedResultOpenOffice, $resultOpenOffice, 'should be OpenOffice compatible');
     }
 
-    public function providerBinaryComparisonOperation(): array
+    public static function providerBinaryComparisonOperation(): array
     {
         return require 'tests/data/CalculationBinaryComparisonOperation.php';
     }
@@ -406,7 +406,7 @@ class CalculationTest extends TestCase
         self::assertEquals($expectedResult, $calculated);
     }
 
-    public function dataProviderBranchPruningFullExecution(): array
+    public static function dataProviderBranchPruningFullExecution(): array
     {
         return require 'tests/data/Calculation/Calculation.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/FormattedNumberTest.php
@@ -19,7 +19,7 @@ class FormattedNumberTest extends TestCase
         self::assertSame($expected, $value);
     }
 
-    public function providerNumbers(): array
+    public static function providerNumbers(): array
     {
         return [
             [-12.5, '-12.5'],
@@ -47,7 +47,7 @@ class FormattedNumberTest extends TestCase
         }
     }
 
-    public function providerFractions(): array
+    public static function providerFractions(): array
     {
         return [
             'non-fraction' => ['1', '1'],
@@ -76,7 +76,7 @@ class FormattedNumberTest extends TestCase
         }
     }
 
-    public function providerPercentages(): array
+    public static function providerPercentages(): array
     {
         return [
             'non-percentage' => ['10', '10'],
@@ -205,7 +205,7 @@ class FormattedNumberTest extends TestCase
         }
     }
 
-    public function providerCurrencies(): array
+    public static function providerCurrencies(): array
     {
         $currencyCode = StringHelper::getCurrencyCode();
 

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/RangeTest.php
@@ -38,7 +38,7 @@ class RangeTest extends TestCase
         self::assertSame($expectedResult, $actualRresult);
     }
 
-    public function providerRangeEvaluation(): array
+    public static function providerRangeEvaluation(): array
     {
         return[
             'Sum with Simple Range' => ['=SUM(A1:C3)', 72],
@@ -93,7 +93,7 @@ class RangeTest extends TestCase
         self::assertSame($expectedResult, $sumRresult);
     }
 
-    public function providerNamedRangeEvaluation(): array
+    public static function providerNamedRangeEvaluation(): array
     {
         return[
             [['$A$1:$B$3', '$A$1:$C$2'], '=SUM(GROUP1,GROUP2)', 75],
@@ -131,7 +131,7 @@ class RangeTest extends TestCase
         self::assertSame($expectedResult, $sumRresult);
     }
 
-    public function providerUTF8NamedRangeEvaluation(): array
+    public static function providerUTF8NamedRangeEvaluation(): array
     {
         return[
             [['Γειά', 'σου', 'Κόσμε'], ['$A$1', '$B$1:$B$2', '$C$1:$C$3'], '=SUM(Γειά,σου,Κόσμε)', 38],
@@ -161,7 +161,7 @@ class RangeTest extends TestCase
         self::assertSame($expectedCount, $actualCount);
     }
 
-    public function providerCompositeNamedRangeEvaluation(): array
+    public static function providerCompositeNamedRangeEvaluation(): array
     {
         return[
             //  Calculation engine doesn't yet handle union ranges with overlap

--- a/tests/PhpSpreadsheetTests/Calculation/Engine/StructuredReferenceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Engine/StructuredReferenceTest.php
@@ -122,7 +122,7 @@ class StructuredReferenceTest extends TestCase
         $structuredReferenceObject->parse($cell);
     }
 
-    public function structuredReferenceProviderColumnData(): array
+    public static function structuredReferenceProviderColumnData(): array
     {
         return [
             // Full table, with no column specified,  means data only, not headers or totals
@@ -151,7 +151,7 @@ class StructuredReferenceTest extends TestCase
         ];
     }
 
-    public function structuredReferenceProviderRowData(): array
+    public static function structuredReferenceProviderRowData(): array
     {
         return [
             ['E5', 'DeptSales[[#This Row], [Commission Amount]]'],

--- a/tests/PhpSpreadsheetTests/Calculation/FormulaAsStringTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FormulaAsStringTest.php
@@ -39,7 +39,7 @@ class FormulaAsStringTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerFunctionsAsString(): array
+    public static function providerFunctionsAsString(): array
     {
         return require 'tests/data/Calculation/FunctionsAsString.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/FormulaParserTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FormulaParserTest.php
@@ -50,7 +50,7 @@ class FormulaParserTest extends TestCase
         }
     }
 
-    public function providerFormulaParser(): array
+    public static function providerFormulaParser(): array
     {
         return [
             ['5%*(2+(-3))+A3',

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateDifTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateDifTest.php
@@ -65,7 +65,7 @@ class DateDifTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDATEDIF(): array
+    public static function providerDATEDIF(): array
     {
         return require 'tests/data/Calculation/DateTime/DATEDIF.php';
     }
@@ -91,7 +91,7 @@ class DateDifTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDATEDIF(): array
+    public static function providerUnhappyDATEDIF(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DATEDIF() function', '2023-03-1'],
@@ -128,7 +128,7 @@ class DateDifTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerDateDifArray(): array
+    public static function providerDateDifArray(): array
     {
         return [
             'row vector #1' => [[[364, 202, '#NUM!']], '{"2022-01-01", "2022-06-12", "2023-07-22"}', '"2022-12-31"', null],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateTest.php
@@ -89,7 +89,7 @@ class DateTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDATE(): array
+    public static function providerDATE(): array
     {
         return require 'tests/data/Calculation/DateTime/DATE.php';
     }
@@ -115,7 +115,7 @@ class DateTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDATE(): array
+    public static function providerUnhappyDATE(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DATE() function', 2023, 03],
@@ -166,7 +166,7 @@ class DateTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerDateArray(): array
+    public static function providerDateArray(): array
     {
         return [
             'row vector year' => [[[44197, 44562, 44927]], '{2021,2022,2023}', '1', '1'],
@@ -234,7 +234,7 @@ class DateTest extends TestCase
         $calculation->_calculateFormulaValue($formula);
     }
 
-    public function providerDateArrayException(): array
+    public static function providerDateArrayException(): array
     {
         return [
             'matrix arguments with 3 array values' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DateValueTest.php
@@ -117,7 +117,7 @@ class DateValueTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDATEVALUE(): array
+    public static function providerDATEVALUE(): array
     {
         return require 'tests/data/Calculation/DateTime/DATEVALUE.php';
     }
@@ -143,7 +143,7 @@ class DateValueTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDATEVALUE(): array
+    public static function providerUnhappyDATEVALUE(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DATEVALUE() function'],
@@ -194,7 +194,7 @@ class DateValueTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerDateValueArray(): array
+    public static function providerDateValueArray(): array
     {
         return [
             'row vector' => [[[44562, 44724, 45129]], '{"2022-01-01", "2022-06-12", "2023-07-22"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DayTest.php
@@ -81,7 +81,7 @@ class DayTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDAY(): array
+    public static function providerDAY(): array
     {
         return require 'tests/data/Calculation/DateTime/DAY.php';
     }
@@ -118,7 +118,7 @@ class DayTest extends TestCase
         self::assertSame($expectedResultOpenOffice, $result);
     }
 
-    public function providerDAYOpenOffice(): array
+    public static function providerDAYOpenOffice(): array
     {
         return require 'tests/data/Calculation/DateTime/DAYOpenOffice.php';
     }
@@ -144,7 +144,7 @@ class DayTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDAY(): array
+    public static function providerUnhappyDAY(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DAY() function'],
@@ -169,7 +169,7 @@ class DayTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerDayArray(): array
+    public static function providerDayArray(): array
     {
         return [
             'row vector' => [[[1, 12, 22]], '{"2022-01-01", "2022-06-12", "2023-07-22"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/Days360Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/Days360Test.php
@@ -66,7 +66,7 @@ class Days360Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDAYS360(): array
+    public static function providerDAYS360(): array
     {
         return require 'tests/data/Calculation/DateTime/DAYS360.php';
     }
@@ -92,7 +92,7 @@ class Days360Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDAYS360(): array
+    public static function providerUnhappyDAYS360(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DAYS360() function'],
@@ -129,7 +129,7 @@ class Days360Test extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerDays360Array(): array
+    public static function providerDays360Array(): array
     {
         return [
             'row vector #1' => [[[360, 199, -201]], '{"2022-01-01", "2022-06-12", "2023-07-22"}', '"2022-12-31"', null],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DaysTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/DaysTest.php
@@ -64,7 +64,7 @@ class DaysTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDAYS(): array
+    public static function providerDAYS(): array
     {
         return require 'tests/data/Calculation/DateTime/DAYS.php';
     }
@@ -90,7 +90,7 @@ class DaysTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDAYS(): array
+    public static function providerUnhappyDAYS(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DAYS() function', '2023-04-01'],
@@ -123,7 +123,7 @@ class DaysTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerDaysArray(): array
+    public static function providerDaysArray(): array
     {
         return [
             'row vector #1' => [[[-364, -202, 203]], '{"2022-01-01", "2022-06-12", "2023-07-22"}', '"2022-12-31"'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EDateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EDateTest.php
@@ -80,7 +80,7 @@ class EDateTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerEDATE(): array
+    public static function providerEDATE(): array
     {
         return require 'tests/data/Calculation/DateTime/EDATE.php';
     }
@@ -106,7 +106,7 @@ class EDateTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyEDATE(): array
+    public static function providerUnhappyEDATE(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for EDATE() function', null],
@@ -148,7 +148,7 @@ class EDateTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerEDateArray(): array
+    public static function providerEDateArray(): array
     {
         return [
             'row vector #1' => [[[44593, 44632, 45337]], '{"2022-01-01", "2022-02-12", "2024-01-15"}', '1'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EoMonthTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/EoMonthTest.php
@@ -80,7 +80,7 @@ class EoMonthTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerEOMONTH(): array
+    public static function providerEOMONTH(): array
     {
         return require 'tests/data/Calculation/DateTime/EOMONTH.php';
     }
@@ -106,7 +106,7 @@ class EoMonthTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyEOMONTH(): array
+    public static function providerUnhappyEOMONTH(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for EOMONTH() function'],
@@ -147,7 +147,7 @@ class EoMonthTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerEoMonthArray(): array
+    public static function providerEoMonthArray(): array
     {
         return [
             'row vector #1' => [[[44620, 44651, 45351]], '{"2022-01-01", "2022-02-12", "2024-01-15"}', '1'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/HourTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/HourTest.php
@@ -61,7 +61,7 @@ class HourTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerHOUR(): array
+    public static function providerHOUR(): array
     {
         return require 'tests/data/Calculation/DateTime/HOUR.php';
     }
@@ -87,7 +87,7 @@ class HourTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyHOUR(): array
+    public static function providerUnhappyHOUR(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for HOUR() function'],
@@ -106,7 +106,7 @@ class HourTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerHourArray(): array
+    public static function providerHourArray(): array
     {
         return [
             'row vector' => [[[1, 13, 19]], '{"2022-02-09 01:02:03", "2022-02-09 13:14:15", "2022-02-09 19:20:21"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/IsoWeekNumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/IsoWeekNumTest.php
@@ -83,7 +83,7 @@ class IsoWeekNumTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerISOWEEKNUM(): array
+    public static function providerISOWEEKNUM(): array
     {
         return require 'tests/data/Calculation/DateTime/ISOWEEKNUM.php';
     }
@@ -109,7 +109,7 @@ class IsoWeekNumTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyISOWEEKNUM(): array
+    public static function providerUnhappyISOWEEKNUM(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for ISOWEEKNUM() function', 2023, 03],
@@ -130,7 +130,7 @@ class IsoWeekNumTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerISOWEEKNUM1904(): array
+    public static function providerISOWEEKNUM1904(): array
     {
         return require 'tests/data/Calculation/DateTime/ISOWEEKNUM1904.php';
     }
@@ -147,7 +147,7 @@ class IsoWeekNumTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerIsoWeekNumArray(): array
+    public static function providerIsoWeekNumArray(): array
     {
         return [
             'row vector' => [[[52, 23, 29]], '{"2022-01-01", "2022-06-12", "2023-07-22"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MinuteTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MinuteTest.php
@@ -61,7 +61,7 @@ class MinuteTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerMINUTE(): array
+    public static function providerMINUTE(): array
     {
         return require 'tests/data/Calculation/DateTime/MINUTE.php';
     }
@@ -87,7 +87,7 @@ class MinuteTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyMINUTE(): array
+    public static function providerUnhappyMINUTE(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for MINUTE() function'],
@@ -106,7 +106,7 @@ class MinuteTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerMinuteArray(): array
+    public static function providerMinuteArray(): array
     {
         return [
             'row vector' => [[[2, 14, 20]], '{"2022-02-09 01:02:03", "2022-02-09 13:14:15", "2022-02-09 19:20:21"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MonthTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/MonthTest.php
@@ -61,7 +61,7 @@ class MonthTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerMONTH(): array
+    public static function providerMONTH(): array
     {
         return require 'tests/data/Calculation/DateTime/MONTH.php';
     }
@@ -87,7 +87,7 @@ class MonthTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyMONTH(): array
+    public static function providerUnhappyMONTH(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for MONTH() function'],
@@ -106,7 +106,7 @@ class MonthTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerMonthArray(): array
+    public static function providerMonthArray(): array
     {
         return [
             'row vector' => [[[1, 6, 1]], '{"2022-01-01", "2022-06-01", "2023-01-01"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/NetworkDaysTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/NetworkDaysTest.php
@@ -59,7 +59,7 @@ class NetworkDaysTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerNETWORKDAYS(): array
+    public static function providerNETWORKDAYS(): array
     {
         return require 'tests/data/Calculation/DateTime/NETWORKDAYS.php';
     }
@@ -85,7 +85,7 @@ class NetworkDaysTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyNETWORKDAYS(): array
+    public static function providerUnhappyNETWORKDAYS(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for NETWORKDAYS() function'],
@@ -109,7 +109,7 @@ class NetworkDaysTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNetWorkDaysArray(): array
+    public static function providerNetWorkDaysArray(): array
     {
         return [
             'row vector #1' => [[[234, 233, 232]], '{"2022-02-01", "2022-02-02", "2022-02-03"}', '"2022-12-25"', null],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/SecondTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/SecondTest.php
@@ -60,7 +60,7 @@ class SecondTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerSECOND(): array
+    public static function providerSECOND(): array
     {
         return require 'tests/data/Calculation/DateTime/SECOND.php';
     }
@@ -86,7 +86,7 @@ class SecondTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappySECOND(): array
+    public static function providerUnhappySECOND(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for SECOND() function'],
@@ -105,7 +105,7 @@ class SecondTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSecondArray(): array
+    public static function providerSecondArray(): array
     {
         return [
             'row vector' => [[[3, 15, 21]], '{"2022-02-09 01:02:03", "2022-02-09 13:14:15", "2022-02-09 19:20:21"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeTest.php
@@ -67,7 +67,7 @@ class TimeTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
-    public function providerTIME(): array
+    public static function providerTIME(): array
     {
         return require 'tests/data/Calculation/DateTime/TIME.php';
     }
@@ -93,7 +93,7 @@ class TimeTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyTIME(): array
+    public static function providerUnhappyTIME(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for TIME() function', 2023, 03],
@@ -147,7 +147,7 @@ class TimeTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTimeArray(): array
+    public static function providerTimeArray(): array
     {
         return [
             'row vector hour' => [[[0.250706018518519, 0.50070601851852, 0.75070601851852]], '{6,12,18}', '1', '1'],
@@ -215,7 +215,7 @@ class TimeTest extends TestCase
         $calculation->_calculateFormulaValue($formula);
     }
 
-    public function providerTimeArrayException(): array
+    public static function providerTimeArrayException(): array
     {
         return [
             'matrix arguments with 3 array values' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/TimeValueTest.php
@@ -81,7 +81,7 @@ class TimeValueTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerTIMEVALUE(): array
+    public static function providerTIMEVALUE(): array
     {
         return require 'tests/data/Calculation/DateTime/TIMEVALUE.php';
     }
@@ -129,7 +129,7 @@ class TimeValueTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyTIMEVALUE(): array
+    public static function providerUnhappyTIMEVALUE(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for TIMEVALUE() function'],
@@ -148,7 +148,7 @@ class TimeValueTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTimeValueArray(): array
+    public static function providerTimeValueArray(): array
     {
         return [
             'row vector' => [[[0.04309027777777, 0.5515625, 0.80579861111111]], '{"2022-02-09 01:02:03", "2022-02-09 13:14:15", "2022-02-09 19:20:21"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekDayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekDayTest.php
@@ -80,7 +80,7 @@ class WeekDayTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerWEEKDAY(): array
+    public static function providerWEEKDAY(): array
     {
         return require 'tests/data/Calculation/DateTime/WEEKDAY.php';
     }
@@ -106,7 +106,7 @@ class WeekDayTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyWEEKDAY(): array
+    public static function providerUnhappyWEEKDAY(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for WEEKDAY() function'],
@@ -134,7 +134,7 @@ class WeekDayTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerWeekDayArray(): array
+    public static function providerWeekDayArray(): array
     {
         return [
             'row vector #1' => [[[7, 1, 7]], '{"2022-01-01", "2022-06-12", "2023-07-22"}', '1'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekNumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WeekNumTest.php
@@ -81,7 +81,7 @@ class WeekNumTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerWEEKNUM(): array
+    public static function providerWEEKNUM(): array
     {
         return require 'tests/data/Calculation/DateTime/WEEKNUM.php';
     }
@@ -107,7 +107,7 @@ class WeekNumTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyWEEKNUM(): array
+    public static function providerUnhappyWEEKNUM(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for WEEKNUM() function'],
@@ -128,7 +128,7 @@ class WeekNumTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerWEEKNUM1904(): array
+    public static function providerWEEKNUM1904(): array
     {
         return require 'tests/data/Calculation/DateTime/WEEKNUM1904.php';
     }
@@ -145,7 +145,7 @@ class WeekNumTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerWeekNumArray(): array
+    public static function providerWeekNumArray(): array
     {
         return [
             'row vector #1' => [[[1, 25, 29]], '{"2022-01-01", "2022-06-12", "2023-07-22"}', '1'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WorkDayTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/WorkDayTest.php
@@ -59,7 +59,7 @@ class WorkDayTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerWORKDAY(): array
+    public static function providerWORKDAY(): array
     {
         return require 'tests/data/Calculation/DateTime/WORKDAY.php';
     }
@@ -85,7 +85,7 @@ class WorkDayTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyWORKDAY(): array
+    public static function providerUnhappyWORKDAY(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for WORKDAY() function'],
@@ -108,7 +108,7 @@ class WorkDayTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerWorkDayArray(): array
+    public static function providerWorkDayArray(): array
     {
         return [
             'row vector #1' => [[[44595, 44596, 44599]], '{"2022-02-01", "2022-02-02", "2022-02-03"}', '2', null],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearFracTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearFracTest.php
@@ -60,7 +60,7 @@ class YearFracTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerYEARFRAC(): array
+    public static function providerYEARFRAC(): array
     {
         return require 'tests/data/Calculation/DateTime/YEARFRAC.php';
     }
@@ -86,7 +86,7 @@ class YearFracTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyYEARFRAC(): array
+    public static function providerUnhappyYEARFRAC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for YEARFRAC() function'],
@@ -110,7 +110,7 @@ class YearFracTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerYearFracArray(): array
+    public static function providerYearFracArray(): array
     {
         return [
             'row vector #1' => [[[1.0, 0.55277777777778, 0.56111111111111]], '{"2022-01-01", "2022-06-12", "2023-07-22"}', '"2022-12-31"', null],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DateTime/YearTest.php
@@ -60,7 +60,7 @@ class YearTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerYEAR(): array
+    public static function providerYEAR(): array
     {
         return require 'tests/data/Calculation/DateTime/YEAR.php';
     }
@@ -86,7 +86,7 @@ class YearTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyYEAR(): array
+    public static function providerUnhappyYEAR(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for YEAR() function'],
@@ -105,7 +105,7 @@ class YearTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerYearArray(): array
+    public static function providerYearArray(): array
     {
         return [
             'row vector' => [[[2021, 2022, 2023]], '{"2021-01-01", "2022-01-01", "2023-01-01"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/DeprecatedExcelErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/DeprecatedExcelErrorTest.php
@@ -19,7 +19,7 @@ class DeprecatedExcelErrorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDeprecatedExcelError(): array
+    public static function providerDeprecatedExcelError(): array
     {
         return [
             'NULL' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselITest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselITest.php
@@ -62,7 +62,7 @@ class BesselITest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBESSELI(): array
+    public static function providerBESSELI(): array
     {
         return require 'tests/data/Calculation/Engineering/BESSELI.php';
     }
@@ -88,7 +88,7 @@ class BesselITest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBESSELI(): array
+    public static function providerUnhappyBESSELI(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BESSELI() function'],
@@ -108,7 +108,7 @@ class BesselITest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::BESSEL_PRECISION);
     }
 
-    public function providerBesselIArray(): array
+    public static function providerBesselIArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselJTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselJTest.php
@@ -62,7 +62,7 @@ class BesselJTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBESSELJ(): array
+    public static function providerBESSELJ(): array
     {
         return require 'tests/data/Calculation/Engineering/BESSELJ.php';
     }
@@ -88,7 +88,7 @@ class BesselJTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBESSELJ(): array
+    public static function providerUnhappyBESSELJ(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BESSELJ() function'],
@@ -108,7 +108,7 @@ class BesselJTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBesselJArray(): array
+    public static function providerBesselJArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselKTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselKTest.php
@@ -62,7 +62,7 @@ class BesselKTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBESSELK(): array
+    public static function providerBESSELK(): array
     {
         return require 'tests/data/Calculation/Engineering/BESSELK.php';
     }
@@ -88,7 +88,7 @@ class BesselKTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBESSELK(): array
+    public static function providerUnhappyBESSELK(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BESSELK() function'],
@@ -108,7 +108,7 @@ class BesselKTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBesselKArray(): array
+    public static function providerBesselKArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselYTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BesselYTest.php
@@ -62,7 +62,7 @@ class BesselYTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBESSELY(): array
+    public static function providerBESSELY(): array
     {
         return require 'tests/data/Calculation/Engineering/BESSELY.php';
     }
@@ -88,7 +88,7 @@ class BesselYTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBESSELY(): array
+    public static function providerUnhappyBESSELY(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BESSELY() function'],
@@ -108,7 +108,7 @@ class BesselYTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBesselYArray(): array
+    public static function providerBesselYArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2DecTest.php
@@ -83,7 +83,7 @@ class Bin2DecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBIN2DEC(): array
+    public static function providerBIN2DEC(): array
     {
         return require 'tests/data/Calculation/Engineering/BIN2DEC.php';
     }
@@ -109,7 +109,7 @@ class Bin2DecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBIN2DEC(): array
+    public static function providerUnhappyBIN2DEC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BIN2DEC() function'],
@@ -130,7 +130,7 @@ class Bin2DecTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerBIN2DECOds(): array
+    public static function providerBIN2DECOds(): array
     {
         return require 'tests/data/Calculation/Engineering/BIN2DECOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Bin2DecTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBin2DecArray(): array
+    public static function providerBin2DecArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2HexTest.php
@@ -83,7 +83,7 @@ class Bin2HexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBIN2HEX(): array
+    public static function providerBIN2HEX(): array
     {
         return require 'tests/data/Calculation/Engineering/BIN2HEX.php';
     }
@@ -109,7 +109,7 @@ class Bin2HexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBIN2HEX(): array
+    public static function providerUnhappyBIN2HEX(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BIN2HEX() function'],
@@ -130,7 +130,7 @@ class Bin2HexTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerBIN2HEXOds(): array
+    public static function providerBIN2HEXOds(): array
     {
         return require 'tests/data/Calculation/Engineering/BIN2HEXOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Bin2HexTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBin2HexArray(): array
+    public static function providerBin2HexArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Bin2OctTest.php
@@ -83,7 +83,7 @@ class Bin2OctTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBIN2OCT(): array
+    public static function providerBIN2OCT(): array
     {
         return require 'tests/data/Calculation/Engineering/BIN2OCT.php';
     }
@@ -109,7 +109,7 @@ class Bin2OctTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBIN2OCT(): array
+    public static function providerUnhappyBIN2OCT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BIN2OCT() function'],
@@ -130,7 +130,7 @@ class Bin2OctTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerBIN2OCTOds(): array
+    public static function providerBIN2OCTOds(): array
     {
         return require 'tests/data/Calculation/Engineering/BIN2OCTOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Bin2OctTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBin2OctArray(): array
+    public static function providerBin2OctArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitAndTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitAndTest.php
@@ -60,7 +60,7 @@ class BitAndTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBITAND(): array
+    public static function providerBITAND(): array
     {
         return require 'tests/data/Calculation/Engineering/BITAND.php';
     }
@@ -86,7 +86,7 @@ class BitAndTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBITAND(): array
+    public static function providerUnhappyBITAND(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BITAND() function'],
@@ -106,7 +106,7 @@ class BitAndTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBitAndArray(): array
+    public static function providerBitAndArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitLShiftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitLShiftTest.php
@@ -60,7 +60,7 @@ class BitLShiftTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBITLSHIFT(): array
+    public static function providerBITLSHIFT(): array
     {
         return require 'tests/data/Calculation/Engineering/BITLSHIFT.php';
     }
@@ -86,7 +86,7 @@ class BitLShiftTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBITLSHIFT(): array
+    public static function providerUnhappyBITLSHIFT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BITLSHIFT() function'],
@@ -106,7 +106,7 @@ class BitLShiftTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBitLShiftArray(): array
+    public static function providerBitLShiftArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitOrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitOrTest.php
@@ -60,7 +60,7 @@ class BitOrTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBITOR(): array
+    public static function providerBITOR(): array
     {
         return require 'tests/data/Calculation/Engineering/BITOR.php';
     }
@@ -86,7 +86,7 @@ class BitOrTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBITOR(): array
+    public static function providerUnhappyBITOR(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BITOR() function'],
@@ -106,7 +106,7 @@ class BitOrTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBitOrArray(): array
+    public static function providerBitOrArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitRShiftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitRShiftTest.php
@@ -60,7 +60,7 @@ class BitRShiftTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBITRSHIFT(): array
+    public static function providerBITRSHIFT(): array
     {
         return require 'tests/data/Calculation/Engineering/BITRSHIFT.php';
     }
@@ -86,7 +86,7 @@ class BitRShiftTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBITRSHIFT(): array
+    public static function providerUnhappyBITRSHIFT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BITRSHIFT() function'],
@@ -106,7 +106,7 @@ class BitRShiftTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBitRShiftArray(): array
+    public static function providerBitRShiftArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitXorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/BitXorTest.php
@@ -60,7 +60,7 @@ class BitXorTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerBITXOR(): array
+    public static function providerBITXOR(): array
     {
         return require 'tests/data/Calculation/Engineering/BITXOR.php';
     }
@@ -86,7 +86,7 @@ class BitXorTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyBITXOR(): array
+    public static function providerUnhappyBITXOR(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for BITXOR() function'],
@@ -106,7 +106,7 @@ class BitXorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBitXorArray(): array
+    public static function providerBitXorArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ComplexTest.php
@@ -65,7 +65,7 @@ class ComplexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerCOMPLEX(): array
+    public static function providerCOMPLEX(): array
     {
         return require 'tests/data/Calculation/Engineering/COMPLEX.php';
     }
@@ -82,7 +82,7 @@ class ComplexTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerComplexArray(): array
+    public static function providerComplexArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ConvertUoMTest.php
@@ -92,7 +92,7 @@ class ConvertUoMTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerCONVERTUOM(): array
+    public static function providerCONVERTUOM(): array
     {
         return require 'tests/data/Calculation/Engineering/CONVERTUOM.php';
     }
@@ -118,7 +118,7 @@ class ConvertUoMTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyCONVERTUOM(): array
+    public static function providerUnhappyCONVERTUOM(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for CONVERT() function'],
@@ -139,7 +139,7 @@ class ConvertUoMTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::UOM_PRECISION);
     }
 
-    public function providerConvertUoMArray(): array
+    public static function providerConvertUoMArray(): array
     {
         return [
             'Weight/Mass' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2BinTest.php
@@ -82,7 +82,7 @@ class Dec2BinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDEC2BIN(): array
+    public static function providerDEC2BIN(): array
     {
         return require 'tests/data/Calculation/Engineering/DEC2BIN.php';
     }
@@ -108,7 +108,7 @@ class Dec2BinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDEC2BIN(): array
+    public static function providerUnhappyDEC2BIN(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DEC2BIN() function'],
@@ -129,7 +129,7 @@ class Dec2BinTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerDEC2BINOds(): array
+    public static function providerDEC2BINOds(): array
     {
         return require 'tests/data/Calculation/Engineering/DEC2BINOpenOffice.php';
     }
@@ -164,7 +164,7 @@ class Dec2BinTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDec2BinArray(): array
+    public static function providerDec2BinArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2HexTest.php
@@ -82,7 +82,7 @@ class Dec2HexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDEC2HEX(): array
+    public static function providerDEC2HEX(): array
     {
         return require 'tests/data/Calculation/Engineering/DEC2HEX.php';
     }
@@ -108,7 +108,7 @@ class Dec2HexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDEC2HEX(): array
+    public static function providerUnhappyDEC2HEX(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DEC2HEX() function'],
@@ -129,7 +129,7 @@ class Dec2HexTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerDEC2HEXOds(): array
+    public static function providerDEC2HEXOds(): array
     {
         return require 'tests/data/Calculation/Engineering/DEC2HEXOpenOffice.php';
     }
@@ -171,7 +171,7 @@ class Dec2HexTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDec2HexArray(): array
+    public static function providerDec2HexArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Dec2OctTest.php
@@ -82,7 +82,7 @@ class Dec2OctTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDEC2OCT(): array
+    public static function providerDEC2OCT(): array
     {
         return require 'tests/data/Calculation/Engineering/DEC2OCT.php';
     }
@@ -108,7 +108,7 @@ class Dec2OctTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDEC2OCT(): array
+    public static function providerUnhappyDEC2OCT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DEC2OCT() function'],
@@ -129,7 +129,7 @@ class Dec2OctTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerDEC2OCTOds(): array
+    public static function providerDEC2OCTOds(): array
     {
         return require 'tests/data/Calculation/Engineering/DEC2OCTOpenOffice.php';
     }
@@ -164,7 +164,7 @@ class Dec2OctTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDec2OctArray(): array
+    public static function providerDec2OctArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/DeltaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/DeltaTest.php
@@ -61,7 +61,7 @@ class DeltaTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDELTA(): array
+    public static function providerDELTA(): array
     {
         return require 'tests/data/Calculation/Engineering/DELTA.php';
     }
@@ -87,7 +87,7 @@ class DeltaTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyDELTA(): array
+    public static function providerUnhappyDELTA(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for DELTA() function'],
@@ -106,7 +106,7 @@ class DeltaTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDeltaArray(): array
+    public static function providerDeltaArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfCTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfCTest.php
@@ -63,7 +63,7 @@ class ErfCTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerERFC(): array
+    public static function providerERFC(): array
     {
         return require 'tests/data/Calculation/Engineering/ERFC.php';
     }
@@ -89,7 +89,7 @@ class ErfCTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyERFC(): array
+    public static function providerUnhappyERFC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for ERFC() function'],
@@ -108,7 +108,7 @@ class ErfCTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    public function providerErfCArray(): array
+    public static function providerErfCArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfPreciseTest.php
@@ -62,7 +62,7 @@ class ErfPreciseTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerERFPRECISE(): array
+    public static function providerERFPRECISE(): array
     {
         return require 'tests/data/Calculation/Engineering/ERFPRECISE.php';
     }
@@ -79,7 +79,7 @@ class ErfPreciseTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    public function providerErfPreciseArray(): array
+    public static function providerErfPreciseArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ErfTest.php
@@ -63,7 +63,7 @@ class ErfTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerERF(): array
+    public static function providerERF(): array
     {
         return require 'tests/data/Calculation/Engineering/ERF.php';
     }
@@ -89,7 +89,7 @@ class ErfTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyERF(): array
+    public static function providerUnhappyERF(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for ERF() function'],
@@ -108,7 +108,7 @@ class ErfTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::ERF_PRECISION);
     }
 
-    public function providerErfArray(): array
+    public static function providerErfArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/GeStepTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/GeStepTest.php
@@ -61,7 +61,7 @@ class GeStepTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerGESTEP(): array
+    public static function providerGESTEP(): array
     {
         return require 'tests/data/Calculation/Engineering/GESTEP.php';
     }
@@ -87,7 +87,7 @@ class GeStepTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyGESTEP(): array
+    public static function providerUnhappyGESTEP(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for GESTEP() function'],
@@ -106,7 +106,7 @@ class GeStepTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerGeStepArray(): array
+    public static function providerGeStepArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2BinTest.php
@@ -83,7 +83,7 @@ class Hex2BinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerHEX2BIN(): array
+    public static function providerHEX2BIN(): array
     {
         return require 'tests/data/Calculation/Engineering/HEX2BIN.php';
     }
@@ -109,7 +109,7 @@ class Hex2BinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyHEX2BIN(): array
+    public static function providerUnhappyHEX2BIN(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for HEX2BIN() function'],
@@ -130,7 +130,7 @@ class Hex2BinTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerHEX2BINOds(): array
+    public static function providerHEX2BINOds(): array
     {
         return require 'tests/data/Calculation/Engineering/HEX2BINOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Hex2BinTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerHex2BinArray(): array
+    public static function providerHex2BinArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2DecTest.php
@@ -83,7 +83,7 @@ class Hex2DecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerHEX2DEC(): array
+    public static function providerHEX2DEC(): array
     {
         return require 'tests/data/Calculation/Engineering/HEX2DEC.php';
     }
@@ -109,7 +109,7 @@ class Hex2DecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyHEX2DEC(): array
+    public static function providerUnhappyHEX2DEC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for HEX2DEC() function'],
@@ -130,7 +130,7 @@ class Hex2DecTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerHEX2DECOds(): array
+    public static function providerHEX2DECOds(): array
     {
         return require 'tests/data/Calculation/Engineering/HEX2DECOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Hex2DecTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerHex2DecArray(): array
+    public static function providerHex2DecArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2OctTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Hex2OctTest.php
@@ -83,7 +83,7 @@ class Hex2OctTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerHEX2OCT(): array
+    public static function providerHEX2OCT(): array
     {
         return require 'tests/data/Calculation/Engineering/HEX2OCT.php';
     }
@@ -109,7 +109,7 @@ class Hex2OctTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyHEX2OCT(): array
+    public static function providerUnhappyHEX2OCT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for HEX2OCT() function'],
@@ -130,7 +130,7 @@ class Hex2OctTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerHEX2OCTOds(): array
+    public static function providerHEX2OCTOds(): array
     {
         return require 'tests/data/Calculation/Engineering/HEX2OCTOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Hex2OctTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerHex2OctArray(): array
+    public static function providerHex2OctArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImAbsTest.php
@@ -63,7 +63,7 @@ class ImAbsTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMABS(): array
+    public static function providerIMABS(): array
     {
         return require 'tests/data/Calculation/Engineering/IMABS.php';
     }
@@ -89,7 +89,7 @@ class ImAbsTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMABS(): array
+    public static function providerUnhappyIMABS(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMABS() function'],
@@ -108,7 +108,7 @@ class ImAbsTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImAbsArray(): array
+    public static function providerImAbsArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImArgumentTest.php
@@ -69,7 +69,7 @@ class ImArgumentTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMARGUMENT(): array
+    public static function providerIMARGUMENT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMARGUMENT.php';
     }
@@ -95,14 +95,14 @@ class ImArgumentTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMARGUMENT(): array
+    public static function providerUnhappyIMARGUMENT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMARGUMENT() function'],
         ];
     }
 
-    public function providerImArgumentArray(): array
+    public static function providerImArgumentArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImConjugateTest.php
@@ -90,7 +90,7 @@ class ImConjugateTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMCONJUGATE(): array
+    public static function providerIMCONJUGATE(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCONJUGATE.php';
     }
@@ -116,7 +116,7 @@ class ImConjugateTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMCONJUGATE(): array
+    public static function providerUnhappyIMCONJUGATE(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMCONJUGATE() function'],
@@ -135,7 +135,7 @@ class ImConjugateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImConjugateArray(): array
+    public static function providerImConjugateArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCosTest.php
@@ -90,7 +90,7 @@ class ImCosTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMCOS(): array
+    public static function providerIMCOS(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCOS.php';
     }
@@ -116,7 +116,7 @@ class ImCosTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMCOS(): array
+    public static function providerUnhappyIMCOS(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMCOS() function'],
@@ -135,7 +135,7 @@ class ImCosTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImCosArray(): array
+    public static function providerImCosArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCoshTest.php
@@ -90,7 +90,7 @@ class ImCoshTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMCOSH(): array
+    public static function providerIMCOSH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCOSH.php';
     }
@@ -116,7 +116,7 @@ class ImCoshTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMCOSH(): array
+    public static function providerUnhappyIMCOSH(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMCOSH() function'],
@@ -135,7 +135,7 @@ class ImCoshTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImCoshArray(): array
+    public static function providerImCoshArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCotTest.php
@@ -90,7 +90,7 @@ class ImCotTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMCOT(): array
+    public static function providerIMCOT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCOT.php';
     }
@@ -116,7 +116,7 @@ class ImCotTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMCOT(): array
+    public static function providerUnhappyIMCOT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMCOT() function'],
@@ -135,7 +135,7 @@ class ImCotTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImCotArray(): array
+    public static function providerImCotArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCscTest.php
@@ -90,7 +90,7 @@ class ImCscTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMCSC(): array
+    public static function providerIMCSC(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCSC.php';
     }
@@ -116,7 +116,7 @@ class ImCscTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMCSC(): array
+    public static function providerUnhappyIMCSC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMCSC() function'],
@@ -147,7 +147,7 @@ class ImCscTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImCscArray(): array
+    public static function providerImCscArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImCschTest.php
@@ -90,7 +90,7 @@ class ImCschTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMCSCH(): array
+    public static function providerIMCSCH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMCSCH.php';
     }
@@ -116,7 +116,7 @@ class ImCschTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMCSCH(): array
+    public static function providerUnhappyIMCSCH(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMCSCH() function'],
@@ -135,7 +135,7 @@ class ImCschTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImCschArray(): array
+    public static function providerImCschArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImDivTest.php
@@ -90,7 +90,7 @@ class ImDivTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMDIV(): array
+    public static function providerIMDIV(): array
     {
         return require 'tests/data/Calculation/Engineering/IMDIV.php';
     }
@@ -116,7 +116,7 @@ class ImDivTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMDIV(): array
+    public static function providerUnhappyIMDIV(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMDIV() function'],
@@ -136,7 +136,7 @@ class ImDivTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImDivArray(): array
+    public static function providerImDivArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImExpTest.php
@@ -90,7 +90,7 @@ class ImExpTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMEXP(): array
+    public static function providerIMEXP(): array
     {
         return require 'tests/data/Calculation/Engineering/IMEXP.php';
     }
@@ -116,7 +116,7 @@ class ImExpTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMEXP(): array
+    public static function providerUnhappyIMEXP(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMEXP() function'],
@@ -135,7 +135,7 @@ class ImExpTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImExpArray(): array
+    public static function providerImExpArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLnTest.php
@@ -90,7 +90,7 @@ class ImLnTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMLN(): array
+    public static function providerIMLN(): array
     {
         return require 'tests/data/Calculation/Engineering/IMLN.php';
     }
@@ -116,7 +116,7 @@ class ImLnTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMLN(): array
+    public static function providerUnhappyIMLN(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMLN() function'],
@@ -135,7 +135,7 @@ class ImLnTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImLnArray(): array
+    public static function providerImLnArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog10Test.php
@@ -90,7 +90,7 @@ class ImLog10Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMLOG10(): array
+    public static function providerIMLOG10(): array
     {
         return require 'tests/data/Calculation/Engineering/IMLOG10.php';
     }
@@ -116,7 +116,7 @@ class ImLog10Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMLOG10(): array
+    public static function providerUnhappyIMLOG10(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMLOG10() function'],
@@ -135,7 +135,7 @@ class ImLog10Test extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImLog10Array(): array
+    public static function providerImLog10Array(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImLog2Test.php
@@ -90,7 +90,7 @@ class ImLog2Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMLOG2(): array
+    public static function providerIMLOG2(): array
     {
         return require 'tests/data/Calculation/Engineering/IMLOG2.php';
     }
@@ -116,7 +116,7 @@ class ImLog2Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMLOG2(): array
+    public static function providerUnhappyIMLOG2(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMLOG2() function'],
@@ -135,7 +135,7 @@ class ImLog2Test extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImLog2Array(): array
+    public static function providerImLog2Array(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImPowerTest.php
@@ -90,7 +90,7 @@ class ImPowerTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMPOWER(): array
+    public static function providerIMPOWER(): array
     {
         return require 'tests/data/Calculation/Engineering/IMPOWER.php';
     }
@@ -116,7 +116,7 @@ class ImPowerTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMPOWER(): array
+    public static function providerUnhappyIMPOWER(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMPOWER() function'],
@@ -135,7 +135,7 @@ class ImPowerTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImPowerArray(): array
+    public static function providerImPowerArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImProductTest.php
@@ -90,7 +90,7 @@ class ImProductTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMPRODUCT(): array
+    public static function providerIMPRODUCT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMPRODUCT.php';
     }
@@ -116,7 +116,7 @@ class ImProductTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMPRODUCT(): array
+    public static function providerUnhappyIMPRODUCT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMPRODUCT() function'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImRealTest.php
@@ -69,7 +69,7 @@ class ImRealTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMREAL(): array
+    public static function providerIMREAL(): array
     {
         return require 'tests/data/Calculation/Engineering/IMREAL.php';
     }
@@ -95,7 +95,7 @@ class ImRealTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMREAL(): array
+    public static function providerUnhappyIMREAL(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMREAL() function'],
@@ -114,7 +114,7 @@ class ImRealTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImRealArray(): array
+    public static function providerImRealArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSecTest.php
@@ -90,7 +90,7 @@ class ImSecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSEC(): array
+    public static function providerIMSEC(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSEC.php';
     }
@@ -116,7 +116,7 @@ class ImSecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSEC(): array
+    public static function providerUnhappyIMSEC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSEC() function'],
@@ -135,7 +135,7 @@ class ImSecTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImSecArray(): array
+    public static function providerImSecArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSechTest.php
@@ -90,7 +90,7 @@ class ImSechTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSECH(): array
+    public static function providerIMSECH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSECH.php';
     }
@@ -116,7 +116,7 @@ class ImSechTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSECH(): array
+    public static function providerUnhappyIMSECH(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSECH() function'],
@@ -135,7 +135,7 @@ class ImSechTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImSecHArray(): array
+    public static function providerImSecHArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinTest.php
@@ -90,7 +90,7 @@ class ImSinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSIN(): array
+    public static function providerIMSIN(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSIN.php';
     }
@@ -116,7 +116,7 @@ class ImSinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSIN(): array
+    public static function providerUnhappyIMSIN(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSIN() function'],
@@ -135,7 +135,7 @@ class ImSinTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImSinArray(): array
+    public static function providerImSinArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSinhTest.php
@@ -90,7 +90,7 @@ class ImSinhTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSINH(): array
+    public static function providerIMSINH(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSINH.php';
     }
@@ -116,7 +116,7 @@ class ImSinhTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSINH(): array
+    public static function providerUnhappyIMSINH(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSINH() function'],
@@ -135,7 +135,7 @@ class ImSinhTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImSinHArray(): array
+    public static function providerImSinHArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSqrtTest.php
@@ -90,7 +90,7 @@ class ImSqrtTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSQRT(): array
+    public static function providerIMSQRT(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSQRT.php';
     }
@@ -116,7 +116,7 @@ class ImSqrtTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSQRT(): array
+    public static function providerUnhappyIMSQRT(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSQRT() function'],
@@ -135,7 +135,7 @@ class ImSqrtTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImSqrtArray(): array
+    public static function providerImSqrtArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSubTest.php
@@ -90,7 +90,7 @@ class ImSubTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSUB(): array
+    public static function providerIMSUB(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSUB.php';
     }
@@ -116,7 +116,7 @@ class ImSubTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSUB(): array
+    public static function providerUnhappyIMSUB(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSUB() function'],
@@ -136,7 +136,7 @@ class ImSubTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImSubArray(): array
+    public static function providerImSubArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImSumTest.php
@@ -90,7 +90,7 @@ class ImSumTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMSUM(): array
+    public static function providerIMSUM(): array
     {
         return require 'tests/data/Calculation/Engineering/IMSUM.php';
     }
@@ -116,7 +116,7 @@ class ImSumTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMSUM(): array
+    public static function providerUnhappyIMSUM(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMSUM() function'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImTanTest.php
@@ -90,7 +90,7 @@ class ImTanTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMTAN(): array
+    public static function providerIMTAN(): array
     {
         return require 'tests/data/Calculation/Engineering/IMTAN.php';
     }
@@ -116,7 +116,7 @@ class ImTanTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMTAN(): array
+    public static function providerUnhappyIMTAN(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMTAN() function'],
@@ -135,7 +135,7 @@ class ImTanTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImTanArray(): array
+    public static function providerImTanArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/ImaginaryTest.php
@@ -69,7 +69,7 @@ class ImaginaryTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIMAGINARY(): array
+    public static function providerIMAGINARY(): array
     {
         return require 'tests/data/Calculation/Engineering/IMAGINARY.php';
     }
@@ -95,7 +95,7 @@ class ImaginaryTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyIMAGINARY(): array
+    public static function providerUnhappyIMAGINARY(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for IMAGINARY() function'],
@@ -114,7 +114,7 @@ class ImaginaryTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerImaginaryArray(): array
+    public static function providerImaginaryArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2BinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2BinTest.php
@@ -83,7 +83,7 @@ class Oct2BinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerOCT2BIN(): array
+    public static function providerOCT2BIN(): array
     {
         return require 'tests/data/Calculation/Engineering/OCT2BIN.php';
     }
@@ -109,7 +109,7 @@ class Oct2BinTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyOCT2BIN(): array
+    public static function providerUnhappyOCT2BIN(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for OCT2BIN() function'],
@@ -130,7 +130,7 @@ class Oct2BinTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerOCT2BINOds(): array
+    public static function providerOCT2BINOds(): array
     {
         return require 'tests/data/Calculation/Engineering/OCT2BINOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Oct2BinTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerOct2BinArray(): array
+    public static function providerOct2BinArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2DecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2DecTest.php
@@ -83,7 +83,7 @@ class Oct2DecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerOCT2DEC(): array
+    public static function providerOCT2DEC(): array
     {
         return require 'tests/data/Calculation/Engineering/OCT2DEC.php';
     }
@@ -109,7 +109,7 @@ class Oct2DecTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyOCT2DEC(): array
+    public static function providerUnhappyOCT2DEC(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for OCT2DEC() function'],
@@ -130,7 +130,7 @@ class Oct2DecTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerOCT2DECOds(): array
+    public static function providerOCT2DECOds(): array
     {
         return require 'tests/data/Calculation/Engineering/OCT2DECOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Oct2DecTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerOct2DecArray(): array
+    public static function providerOct2DecArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2HexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Engineering/Oct2HexTest.php
@@ -83,7 +83,7 @@ class Oct2HexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerOCT2HEX(): array
+    public static function providerOCT2HEX(): array
     {
         return require 'tests/data/Calculation/Engineering/OCT2HEX.php';
     }
@@ -109,7 +109,7 @@ class Oct2HexTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerUnhappyOCT2HEX(): array
+    public static function providerUnhappyOCT2HEX(): array
     {
         return [
             ['Formula Error: Wrong number of arguments for OCT2HEX() function'],
@@ -130,7 +130,7 @@ class Oct2HexTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerOCT2HEXOds(): array
+    public static function providerOCT2HEXOds(): array
     {
         return require 'tests/data/Calculation/Engineering/OCT2HEXOpenOffice.php';
     }
@@ -165,7 +165,7 @@ class Oct2HexTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerOct2HexArray(): array
+    public static function providerOct2HexArray(): array
     {
         return [
             'row/column vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintMTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintMTest.php
@@ -14,7 +14,7 @@ class AccrintMTest extends AllSetupTeardown
         $this->runTestCase('ACCRINTM', $expectedResult, $args);
     }
 
-    public function providerACCRINTM(): array
+    public static function providerACCRINTM(): array
     {
         return require 'tests/data/Calculation/Financial/ACCRINTM.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AccrintTest.php
@@ -14,7 +14,7 @@ class AccrintTest extends AllSetupTeardown
         $this->runTestCase('ACCRINT', $expectedResult, $args);
     }
 
-    public function providerACCRINT(): array
+    public static function providerACCRINT(): array
     {
         return require 'tests/data/Calculation/Financial/ACCRINT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AmorDegRcTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AmorDegRcTest.php
@@ -14,7 +14,7 @@ class AmorDegRcTest extends AllSetupTeardown
         $this->runTestCase('AMORDEGRC', $expectedResult, $args);
     }
 
-    public function providerAMORDEGRC(): array
+    public static function providerAMORDEGRC(): array
     {
         return require 'tests/data/Calculation/Financial/AMORDEGRC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AmorLincTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/AmorLincTest.php
@@ -14,7 +14,7 @@ class AmorLincTest extends AllSetupTeardown
         $this->runTestCase('AMORLINC', $expectedResult, $args);
     }
 
-    public function providerAMORLINC(): array
+    public static function providerAMORLINC(): array
     {
         return require 'tests/data/Calculation/Financial/AMORLINC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupDayBsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupDayBsTest.php
@@ -14,7 +14,7 @@ class CoupDayBsTest extends AllSetupTeardown
         $this->runTestCase('COUPDAYBS', $expectedResult, $args);
     }
 
-    public function providerCOUPDAYBS(): array
+    public static function providerCOUPDAYBS(): array
     {
         return require 'tests/data/Calculation/Financial/COUPDAYBS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupDaysNcTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupDaysNcTest.php
@@ -14,7 +14,7 @@ class CoupDaysNcTest extends AllSetupTeardown
         $this->runTestCase('COUPDAYSNC', $expectedResult, $args);
     }
 
-    public function providerCOUPDAYSNC(): array
+    public static function providerCOUPDAYSNC(): array
     {
         return require 'tests/data/Calculation/Financial/COUPDAYSNC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupDaysTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupDaysTest.php
@@ -14,7 +14,7 @@ class CoupDaysTest extends AllSetupTeardown
         $this->runTestCase('COUPDAYS', $expectedResult, $args);
     }
 
-    public function providerCOUPDAYS(): array
+    public static function providerCOUPDAYS(): array
     {
         return require 'tests/data/Calculation/Financial/COUPDAYS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupNcdTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupNcdTest.php
@@ -14,7 +14,7 @@ class CoupNcdTest extends AllSetupTeardown
         $this->runTestCase('COUPNCD', $expectedResult, $args);
     }
 
-    public function providerCOUPNCD(): array
+    public static function providerCOUPNCD(): array
     {
         return require 'tests/data/Calculation/Financial/COUPNCD.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupNumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupNumTest.php
@@ -14,7 +14,7 @@ class CoupNumTest extends AllSetupTeardown
         $this->runTestCase('COUPNUM', $expectedResult, $args);
     }
 
-    public function providerCOUPNUM(): array
+    public static function providerCOUPNUM(): array
     {
         return require 'tests/data/Calculation/Financial/COUPNUM.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupPcdTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CoupPcdTest.php
@@ -14,7 +14,7 @@ class CoupPcdTest extends AllSetupTeardown
         $this->runTestCase('COUPPCD', $expectedResult, $args);
     }
 
-    public function providerCOUPPCD(): array
+    public static function providerCOUPPCD(): array
     {
         return require 'tests/data/Calculation/Financial/COUPPCD.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CumIpmtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CumIpmtTest.php
@@ -14,7 +14,7 @@ class CumIpmtTest extends AllSetupTeardown
         $this->runTestCase('CUMIPMT', $expectedResult, $args);
     }
 
-    public function providerCUMIPMT(): array
+    public static function providerCUMIPMT(): array
     {
         return require 'tests/data/Calculation/Financial/CUMIPMT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CumPrincTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/CumPrincTest.php
@@ -14,7 +14,7 @@ class CumPrincTest extends AllSetupTeardown
         $this->runTestCase('CUMPRINC', $expectedResult, $args);
     }
 
-    public function providerCUMPRINC(): array
+    public static function providerCUMPRINC(): array
     {
         return require 'tests/data/Calculation/Financial/CUMPRINC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DbTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DbTest.php
@@ -14,7 +14,7 @@ class DbTest extends AllSetupTeardown
         $this->runTestCase('DB', $expectedResult, $args);
     }
 
-    public function providerDB(): array
+    public static function providerDB(): array
     {
         return require 'tests/data/Calculation/Financial/DB.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DdbTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DdbTest.php
@@ -14,7 +14,7 @@ class DdbTest extends AllSetupTeardown
         $this->runTestCase('DDB', $expectedResult, $args);
     }
 
-    public function providerDDB(): array
+    public static function providerDDB(): array
     {
         return require 'tests/data/Calculation/Financial/DDB.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DiscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DiscTest.php
@@ -14,7 +14,7 @@ class DiscTest extends AllSetupTeardown
         $this->runTestCase('DISC', $expectedResult, $args);
     }
 
-    public function providerDISC(): array
+    public static function providerDISC(): array
     {
         return require 'tests/data/Calculation/Financial/DISC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DollarDeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DollarDeTest.php
@@ -16,7 +16,7 @@ class DollarDeTest extends AllSetupTeardown
         $this->runTestCase('DOLLARDE', $expectedResult, $args);
     }
 
-    public function providerDOLLARDE(): array
+    public static function providerDOLLARDE(): array
     {
         return require 'tests/data/Calculation/Financial/DOLLARDE.php';
     }
@@ -33,7 +33,7 @@ class DollarDeTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
-    public function providerDollarDeArray(): array
+    public static function providerDollarDeArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DollarFrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/DollarFrTest.php
@@ -14,7 +14,7 @@ class DollarFrTest extends AllSetupTeardown
         $this->runTestCase('DOLLARFR', $expectedResult, $args);
     }
 
-    public function providerDOLLARFR(): array
+    public static function providerDOLLARFR(): array
     {
         return require 'tests/data/Calculation/Financial/DOLLARFR.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/EffectTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/EffectTest.php
@@ -14,7 +14,7 @@ class EffectTest extends AllSetupTeardown
         $this->runTestCase('EFFECT', $expectedResult, $args);
     }
 
-    public function providerEFFECT(): array
+    public static function providerEFFECT(): array
     {
         return require 'tests/data/Calculation/Financial/EFFECT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/FvScheduleTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/FvScheduleTest.php
@@ -35,7 +35,7 @@ class FvScheduleTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0E-8);
     }
 
-    public function providerFVSCHEDULE(): array
+    public static function providerFVSCHEDULE(): array
     {
         return require 'tests/data/Calculation/Financial/FVSCHEDULE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/FvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/FvTest.php
@@ -14,7 +14,7 @@ class FvTest extends AllSetupTeardown
         $this->runTestCase('FV', $expectedResult, $args);
     }
 
-    public function providerFV(): array
+    public static function providerFV(): array
     {
         return require 'tests/data/Calculation/Financial/FV.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/HelpersTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/HelpersTest.php
@@ -20,7 +20,7 @@ class HelpersTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerDaysPerYear(): array
+    public static function providerDaysPerYear(): array
     {
         return require 'tests/data/Calculation/Financial/DaysPerYear.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IPmtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IPmtTest.php
@@ -14,7 +14,7 @@ class IPmtTest extends AllSetupTeardown
         $this->runTestCase('IPMT', $expectedResult, $args);
     }
 
-    public function providerIPMT(): array
+    public static function providerIPMT(): array
     {
         return require 'tests/data/Calculation/Financial/IPMT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IntRateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IntRateTest.php
@@ -14,7 +14,7 @@ class IntRateTest extends AllSetupTeardown
         $this->runTestCase('INTRATE', $expectedResult, $args);
     }
 
-    public function providerINTRATE(): array
+    public static function providerINTRATE(): array
     {
         return require 'tests/data/Calculation/Financial/INTRATE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IrrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IrrTest.php
@@ -43,7 +43,7 @@ class IrrTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 0.1E-8);
     }
 
-    public function providerIRR(): array
+    public static function providerIRR(): array
     {
         return require 'tests/data/Calculation/Financial/IRR.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IsPmtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/IsPmtTest.php
@@ -14,7 +14,7 @@ class IsPmtTest extends AllSetupTeardown
         $this->runTestCase('ISPMT', $expectedResult, $args);
     }
 
-    public function providerISPMT(): array
+    public static function providerISPMT(): array
     {
         return require 'tests/data/Calculation/Financial/ISPMT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/MirrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/MirrTest.php
@@ -47,7 +47,7 @@ class MirrTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0E-8);
     }
 
-    public function providerMIRR(): array
+    public static function providerMIRR(): array
     {
         return require 'tests/data/Calculation/Financial/MIRR.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/NPerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/NPerTest.php
@@ -14,7 +14,7 @@ class NPerTest extends AllSetupTeardown
         $this->runTestCase('NPER', $expectedResult, $args);
     }
 
-    public function providerNPER(): array
+    public static function providerNPER(): array
     {
         return require 'tests/data/Calculation/Financial/NPER.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/NominalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/NominalTest.php
@@ -14,7 +14,7 @@ class NominalTest extends AllSetupTeardown
         $this->runTestCase('NOMINAL', $expectedResult, $args);
     }
 
-    public function providerNOMINAL(): array
+    public static function providerNOMINAL(): array
     {
         return require 'tests/data/Calculation/Financial/NOMINAL.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/NpvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/NpvTest.php
@@ -14,7 +14,7 @@ class NpvTest extends AllSetupTeardown
         $this->runTestCase('NPV', $expectedResult, $args);
     }
 
-    public function providerNPV(): array
+    public static function providerNPV(): array
     {
         return require 'tests/data/Calculation/Financial/NPV.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PDurationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PDurationTest.php
@@ -14,7 +14,7 @@ class PDurationTest extends AllSetupTeardown
         $this->runTestCase('PDURATION', $expectedResult, $args);
     }
 
-    public function providerPDURATION(): array
+    public static function providerPDURATION(): array
     {
         return require 'tests/data/Calculation/Financial/PDURATION.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PmtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PmtTest.php
@@ -14,7 +14,7 @@ class PmtTest extends AllSetupTeardown
         $this->runTestCase('PMT', $expectedResult, $args);
     }
 
-    public function providerPMT(): array
+    public static function providerPMT(): array
     {
         return require 'tests/data/Calculation/Financial/PMT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PpmtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PpmtTest.php
@@ -14,7 +14,7 @@ class PpmtTest extends AllSetupTeardown
         $this->runTestCase('PPMT', $expectedResult, $args);
     }
 
-    public function providerPPMT(): array
+    public static function providerPPMT(): array
     {
         return require 'tests/data/Calculation/Financial/PPMT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PriceDiscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PriceDiscTest.php
@@ -14,7 +14,7 @@ class PriceDiscTest extends AllSetupTeardown
         $this->runTestCase('PRICEDISC', $expectedResult, $args);
     }
 
-    public function providerPRICEDISC(): array
+    public static function providerPRICEDISC(): array
     {
         return require 'tests/data/Calculation/Financial/PRICEDISC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PriceMatTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PriceMatTest.php
@@ -14,7 +14,7 @@ class PriceMatTest extends AllSetupTeardown
         $this->runTestCase('PRICEMAT', $expectedResult, $args);
     }
 
-    public function providerPRICEMAT(): array
+    public static function providerPRICEMAT(): array
     {
         return require 'tests/data/Calculation/Financial/PRICEMAT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PriceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PriceTest.php
@@ -14,7 +14,7 @@ class PriceTest extends AllSetupTeardown
         $this->runTestCase('PRICE', $expectedResult, $args);
     }
 
-    public function providerPRICE(): array
+    public static function providerPRICE(): array
     {
         return require 'tests/data/Calculation/Financial/PRICE.php';
     }
@@ -32,7 +32,7 @@ class PriceTest extends AllSetupTeardown
         $this->runTestCase('PRICE', $expectedResult, $args);
     }
 
-    public function providerPRICE3(): array
+    public static function providerPRICE3(): array
     {
         return require 'tests/data/Calculation/Financial/PRICE3.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/PvTest.php
@@ -14,7 +14,7 @@ class PvTest extends AllSetupTeardown
         $this->runTestCase('PV', $expectedResult, $args);
     }
 
-    public function providerPV(): array
+    public static function providerPV(): array
     {
         return require 'tests/data/Calculation/Financial/PV.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/RateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/RateTest.php
@@ -14,7 +14,7 @@ class RateTest extends AllSetupTeardown
         $this->runTestCase('RATE', $expectedResult, $args);
     }
 
-    public function providerRATE(): array
+    public static function providerRATE(): array
     {
         return require 'tests/data/Calculation/Financial/RATE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/ReceivedTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/ReceivedTest.php
@@ -14,7 +14,7 @@ class ReceivedTest extends AllSetupTeardown
         $this->runTestCase('RECEIVED', $expectedResult, $args);
     }
 
-    public function providerRECEIVED(): array
+    public static function providerRECEIVED(): array
     {
         return require 'tests/data/Calculation/Financial/RECEIVED.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/RriTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/RriTest.php
@@ -14,7 +14,7 @@ class RriTest extends AllSetupTeardown
         $this->runTestCase('RRI', $expectedResult, $args);
     }
 
-    public function providerRRI(): array
+    public static function providerRRI(): array
     {
         return require 'tests/data/Calculation/Financial/RRI.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/SlnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/SlnTest.php
@@ -14,7 +14,7 @@ class SlnTest extends AllSetupTeardown
         $this->runTestCase('SLN', $expectedResult, $args);
     }
 
-    public function providerSLN(): array
+    public static function providerSLN(): array
     {
         return require 'tests/data/Calculation/Financial/SLN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/SydTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/SydTest.php
@@ -14,7 +14,7 @@ class SydTest extends AllSetupTeardown
         $this->runTestCase('SYD', $expectedResult, $args);
     }
 
-    public function providerSYD(): array
+    public static function providerSYD(): array
     {
         return require 'tests/data/Calculation/Financial/SYD.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/TBillEqTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/TBillEqTest.php
@@ -14,7 +14,7 @@ class TBillEqTest extends AllSetupTeardown
         $this->runTestCase('TBILLEQ', $expectedResult, $args);
     }
 
-    public function providerTBILLEQ(): array
+    public static function providerTBILLEQ(): array
     {
         return require 'tests/data/Calculation/Financial/TBILLEQ.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/TBillPriceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/TBillPriceTest.php
@@ -14,7 +14,7 @@ class TBillPriceTest extends AllSetupTeardown
         $this->runTestCase('TBILLPRICE', $expectedResult, $args);
     }
 
-    public function providerTBILLPRICE(): array
+    public static function providerTBILLPRICE(): array
     {
         return require 'tests/data/Calculation/Financial/TBILLPRICE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/TBillYieldTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/TBillYieldTest.php
@@ -14,7 +14,7 @@ class TBillYieldTest extends AllSetupTeardown
         $this->runTestCase('TBILLYIELD', $expectedResult, $args);
     }
 
-    public function providerTBILLYIELD(): array
+    public static function providerTBILLYIELD(): array
     {
         return require 'tests/data/Calculation/Financial/TBILLYIELD.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/UsDollarTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/UsDollarTest.php
@@ -14,7 +14,7 @@ class UsDollarTest extends AllSetupTeardown
         $this->runTestCase('USDOLLAR', $expectedResult, $args);
     }
 
-    public function providerUSDOLLAR(): array
+    public static function providerUSDOLLAR(): array
     {
         return require 'tests/data/Calculation/Financial/USDOLLAR.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/XNpvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/XNpvTest.php
@@ -63,7 +63,7 @@ class XNpvTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerXNPV(): array
+    public static function providerXNPV(): array
     {
         return require 'tests/data/Calculation/Financial/XNPV.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/XirrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/XirrTest.php
@@ -57,7 +57,7 @@ class XirrTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 0.1E-7);
     }
 
-    public function providerXIRR(): array
+    public static function providerXIRR(): array
     {
         return require 'tests/data/Calculation/Financial/XIRR.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/YieldDiscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/YieldDiscTest.php
@@ -14,7 +14,7 @@ class YieldDiscTest extends AllSetupTeardown
         $this->runTestCase('YIELDDISC', $expectedResult, $args);
     }
 
-    public function providerYIELDDISC(): array
+    public static function providerYIELDDISC(): array
     {
         return require 'tests/data/Calculation/Financial/YIELDDISC.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/YieldMatTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Financial/YieldMatTest.php
@@ -14,7 +14,7 @@ class YieldMatTest extends AllSetupTeardown
         $this->runTestCase('YIELDMAT', $expectedResult, $args);
     }
 
-    public function providerYIELDMAT(): array
+    public static function providerYIELDMAT(): array
     {
         return require 'tests/data/Calculation/Financial/YIELDMAT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/ErrorTypeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/ErrorTypeTest.php
@@ -26,7 +26,7 @@ class ErrorTypeTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerErrorType(): array
+    public static function providerErrorType(): array
     {
         return require 'tests/data/Calculation/Information/ERROR_TYPE.php';
     }
@@ -43,7 +43,7 @@ class ErrorTypeTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerErrorTypeArray(): array
+    public static function providerErrorTypeArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsBlankTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsBlankTest.php
@@ -25,7 +25,7 @@ class IsBlankTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsBlank(): array
+    public static function providerIsBlank(): array
     {
         return require 'tests/data/Calculation/Information/IS_BLANK.php';
     }
@@ -42,7 +42,7 @@ class IsBlankTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsBlankArray(): array
+    public static function providerIsBlankArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrTest.php
@@ -25,7 +25,7 @@ class IsErrTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsErr(): array
+    public static function providerIsErr(): array
     {
         return require 'tests/data/Calculation/Information/IS_ERR.php';
     }
@@ -42,7 +42,7 @@ class IsErrTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsErrArray(): array
+    public static function providerIsErrArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsErrorTest.php
@@ -25,7 +25,7 @@ class IsErrorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsError(): array
+    public static function providerIsError(): array
     {
         return require 'tests/data/Calculation/Information/IS_ERROR.php';
     }
@@ -42,7 +42,7 @@ class IsErrorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsErrorArray(): array
+    public static function providerIsErrorArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsEvenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsEvenTest.php
@@ -27,7 +27,7 @@ class IsEvenTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsEven(): array
+    public static function providerIsEven(): array
     {
         return require 'tests/data/Calculation/Information/IS_EVEN.php';
     }
@@ -44,7 +44,7 @@ class IsEvenTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsEvenArray(): array
+    public static function providerIsEvenArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsLogicalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsLogicalTest.php
@@ -25,7 +25,7 @@ class IsLogicalTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsLogical(): array
+    public static function providerIsLogical(): array
     {
         return require 'tests/data/Calculation/Information/IS_LOGICAL.php';
     }
@@ -42,7 +42,7 @@ class IsLogicalTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsLogicalArray(): array
+    public static function providerIsLogicalArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNaTest.php
@@ -25,7 +25,7 @@ class IsNaTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsNa(): array
+    public static function providerIsNa(): array
     {
         return require 'tests/data/Calculation/Information/IS_NA.php';
     }
@@ -42,7 +42,7 @@ class IsNaTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsNaArray(): array
+    public static function providerIsNaArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNonTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNonTextTest.php
@@ -25,7 +25,7 @@ class IsNonTextTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsNonText(): array
+    public static function providerIsNonText(): array
     {
         return require 'tests/data/Calculation/Information/IS_NONTEXT.php';
     }
@@ -42,7 +42,7 @@ class IsNonTextTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsNonTextArray(): array
+    public static function providerIsNonTextArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNumberTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsNumberTest.php
@@ -25,7 +25,7 @@ class IsNumberTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsNumber(): array
+    public static function providerIsNumber(): array
     {
         return require 'tests/data/Calculation/Information/IS_NUMBER.php';
     }
@@ -42,7 +42,7 @@ class IsNumberTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsNumberArray(): array
+    public static function providerIsNumberArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsOddTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsOddTest.php
@@ -27,7 +27,7 @@ class IsOddTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsOdd(): array
+    public static function providerIsOdd(): array
     {
         return require 'tests/data/Calculation/Information/IS_ODD.php';
     }
@@ -44,7 +44,7 @@ class IsOddTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsOddArray(): array
+    public static function providerIsOddArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/IsTextTest.php
@@ -25,7 +25,7 @@ class IsTextTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsText(): array
+    public static function providerIsText(): array
     {
         return require 'tests/data/Calculation/Information/IS_TEXT.php';
     }
@@ -42,7 +42,7 @@ class IsTextTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsTextArray(): array
+    public static function providerIsTextArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/NTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/NTest.php
@@ -25,7 +25,7 @@ class NTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
-    public function providerN(): array
+    public static function providerN(): array
     {
         return require 'tests/data/Calculation/Information/N.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Information/TypeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Information/TypeTest.php
@@ -24,7 +24,7 @@ class TypeTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerTYPE(): array
+    public static function providerTYPE(): array
     {
         return require 'tests/data/Calculation/Information/TYPE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AndTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/AndTest.php
@@ -14,7 +14,7 @@ class AndTest extends AllSetupTeardown
         $this->runTestCase('AND', $expectedResult, ...$args);
     }
 
-    public function providerAND(): array
+    public static function providerAND(): array
     {
         return require 'tests/data/Calculation/Logical/AND.php';
     }
@@ -32,7 +32,7 @@ class AndTest extends AllSetupTeardown
         self::assertSame($expectedResult, $sheet->getCell('A1')->getCalculatedValue());
     }
 
-    public function providerANDLiteral(): array
+    public static function providerANDLiteral(): array
     {
         return require 'tests/data/Calculation/Logical/ANDLiteral.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfErrorTest.php
@@ -16,7 +16,7 @@ class IfErrorTest extends AllSetupTeardown
         $this->runTestCase('IFERROR', $expectedResult, ...$args);
     }
 
-    public function providerIFERROR(): array
+    public static function providerIFERROR(): array
     {
         return require 'tests/data/Calculation/Logical/IFERROR.php';
     }
@@ -33,7 +33,7 @@ class IfErrorTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIfErrorArray(): array
+    public static function providerIfErrorArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfNaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfNaTest.php
@@ -16,7 +16,7 @@ class IfNaTest extends AllSetupTeardown
         $this->runTestCase('IFNA', $expectedResult, ...$args);
     }
 
-    public function providerIFNA(): array
+    public static function providerIFNA(): array
     {
         return require 'tests/data/Calculation/Logical/IFNA.php';
     }
@@ -33,7 +33,7 @@ class IfNaTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIfNaArray(): array
+    public static function providerIfNaArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfTest.php
@@ -14,7 +14,7 @@ class IfTest extends AllSetupTeardown
         $this->runTestCase('IF', $expectedResult, ...$args);
     }
 
-    public function providerIF(): array
+    public static function providerIF(): array
     {
         return require 'tests/data/Calculation/Logical/IF.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/IfsTest.php
@@ -17,7 +17,7 @@ class IfsTest extends AllSetupTeardown
         $this->runTestCase('IFS', $expectedResult, ...$args);
     }
 
-    public function providerIFS(): array
+    public static function providerIFS(): array
     {
         return require 'tests/data/Calculation/Logical/IFS.php';
     }
@@ -34,7 +34,7 @@ class IfsTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIfsArray(): array
+    public static function providerIfsArray(): array
     {
         return [
             'array return first item' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/NotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/NotTest.php
@@ -16,7 +16,7 @@ class NotTest extends AllSetupTeardown
         $this->runTestCase('NOT', $expectedResult, ...$args);
     }
 
-    public function providerNOT(): array
+    public static function providerNOT(): array
     {
         return require 'tests/data/Calculation/Logical/NOT.php';
     }
@@ -33,7 +33,7 @@ class NotTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerNotArray(): array
+    public static function providerNotArray(): array
     {
         return [
             'vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/OrTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/OrTest.php
@@ -14,7 +14,7 @@ class OrTest extends AllSetupTeardown
         $this->runTestCase('OR', $expectedResult, ...$args);
     }
 
-    public function providerOR(): array
+    public static function providerOR(): array
     {
         return require 'tests/data/Calculation/Logical/OR.php';
     }
@@ -32,7 +32,7 @@ class OrTest extends AllSetupTeardown
         self::assertSame($expectedResult, $sheet->getCell('A1')->getCalculatedValue());
     }
 
-    public function providerORLiteral(): array
+    public static function providerORLiteral(): array
     {
         return require 'tests/data/Calculation/Logical/ORLiteral.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/SwitchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/SwitchTest.php
@@ -16,7 +16,7 @@ class SwitchTest extends AllSetupTeardown
         $this->runTestCase('SWITCH', $expectedResult, ...$args);
     }
 
-    public function providerSwitch(): array
+    public static function providerSwitch(): array
     {
         return require 'tests/data/Calculation/Logical/SWITCH.php';
     }
@@ -37,7 +37,7 @@ class SwitchTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerSwitchArray(): array
+    public static function providerSwitchArray(): array
     {
         return [
             'Array return' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/XorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Logical/XorTest.php
@@ -14,7 +14,7 @@ class XorTest extends AllSetupTeardown
         $this->runTestCase('XOR', $expectedResult, ...$args);
     }
 
-    public function providerXOR(): array
+    public static function providerXOR(): array
     {
         return require 'tests/data/Calculation/Logical/XOR.php';
     }
@@ -32,7 +32,7 @@ class XorTest extends AllSetupTeardown
         self::assertSame($expectedResult, $sheet->getCell('A1')->getCalculatedValue());
     }
 
-    public function providerXORLiteral(): array
+    public static function providerXORLiteral(): array
     {
         return require 'tests/data/Calculation/Logical/XORLiteral.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AddressInternationalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AddressInternationalTest.php
@@ -38,7 +38,7 @@ class AddressInternationalTest extends AllSetupTeardown
         self::assertSame($c, $sheet->getCell('A2')->getCalculatedValue());
     }
 
-    public function providerInternational(): array
+    public static function providerInternational(): array
     {
         return [
             'Default' => ['', 'R', 'C'],
@@ -68,7 +68,7 @@ class AddressInternationalTest extends AllSetupTeardown
         self::assertSame($c, $sheet->getCell('A2')->getCalculatedValue());
     }
 
-    public function providerCompatibility(): array
+    public static function providerCompatibility(): array
     {
         return [
             [Functions::COMPATIBILITY_EXCEL, 'Z', 'S'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AddressTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/AddressTest.php
@@ -19,7 +19,7 @@ class AddressTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerADDRESS(): array
+    public static function providerADDRESS(): array
     {
         return require 'tests/data/Calculation/LookupRef/ADDRESS.php';
     }
@@ -36,7 +36,7 @@ class AddressTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerAddressArray(): array
+    public static function providerAddressArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ChooseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ChooseTest.php
@@ -19,7 +19,7 @@ class ChooseTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCHOOSE(): array
+    public static function providerCHOOSE(): array
     {
         return require 'tests/data/Calculation/LookupRef/CHOOSE.php';
     }
@@ -37,7 +37,7 @@ class ChooseTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerChooseArray(): array
+    public static function providerChooseArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnOnSpreadsheetTest.php
@@ -33,7 +33,7 @@ class ColumnOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerCOLUMNonSpreadsheet(): array
+    public static function providerCOLUMNonSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/COLUMNonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnTest.php
@@ -18,7 +18,7 @@ class ColumnTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerCOLUMN(): array
+    public static function providerCOLUMN(): array
     {
         return require 'tests/data/Calculation/LookupRef/COLUMN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsOnSpreadsheetTest.php
@@ -36,7 +36,7 @@ class ColumnsOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerCOLUMNSonSpreadsheet(): array
+    public static function providerCOLUMNSonSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/COLUMNSonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/ColumnsTest.php
@@ -20,7 +20,7 @@ class ColumnsTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCOLUMNS(): array
+    public static function providerCOLUMNS(): array
     {
         return require 'tests/data/Calculation/LookupRef/COLUMNS.php';
     }
@@ -37,7 +37,7 @@ class ColumnsTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerColumnsArray(): array
+    public static function providerColumnsArray(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/FormulaTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/FormulaTextTest.php
@@ -26,7 +26,7 @@ class FormulaTextTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerFormulaText(): array
+    public static function providerFormulaText(): array
     {
         return require 'tests/data/Calculation/LookupRef/FORMULATEXT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HLookupTest.php
@@ -63,7 +63,7 @@ class HLookupTest extends TestCase
         return $rangeLookup ? ', true' : ', false';
     }
 
-    public function providerHLOOKUP(): array
+    public static function providerHLOOKUP(): array
     {
         return require 'tests/data/Calculation/LookupRef/HLOOKUP.php';
     }
@@ -96,7 +96,7 @@ class HLookupTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerHLookupNamedRange(): array
+    public static function providerHLookupNamedRange(): array
     {
         return [
             ['Average', 'D5'],
@@ -118,7 +118,7 @@ class HLookupTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerHLookupArray(): array
+    public static function providerHLookupArray(): array
     {
         return [
             'row vector #1' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HyperlinkTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/HyperlinkTest.php
@@ -89,7 +89,7 @@ class HyperlinkTest extends AllSetupTeardown
         }
     }
 
-    public function providerHYPERLINK(): array
+    public static function providerHYPERLINK(): array
     {
         return require 'tests/data/Calculation/LookupRef/HYPERLINK.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndexOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndexOnSpreadsheetTest.php
@@ -32,7 +32,7 @@ class IndexOnSpreadsheetTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerINDEXonSpreadsheet(): array
+    public static function providerINDEXonSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/INDEXonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndexTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndexTest.php
@@ -29,7 +29,7 @@ class IndexTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerINDEX(): array
+    public static function providerINDEX(): array
     {
         return require 'tests/data/Calculation/LookupRef/INDEX.php';
     }
@@ -46,7 +46,7 @@ class IndexTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIndexArray(): array
+    public static function providerIndexArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectInternationalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectInternationalTest.php
@@ -62,7 +62,7 @@ class IndirectInternationalTest extends AllSetupTeardown
         }
     }
 
-    public function providerInternational(): array
+    public static function providerInternational(): array
     {
         return [
             'English' => ['en'],
@@ -89,7 +89,7 @@ class IndirectInternationalTest extends AllSetupTeardown
         self::assertSame('text', $sheet->getCell($cell)->getCalculatedValue());
     }
 
-    public function providerRelativeInternational(): array
+    public static function providerRelativeInternational(): array
     {
         return [
             'English A3' => ['en', 'A3', 'R[]C[+2]'],
@@ -121,7 +121,7 @@ class IndirectInternationalTest extends AllSetupTeardown
         self::assertSame($expected2, $sheet->getCell('A2')->getCalculatedValue());
     }
 
-    public function providerCompatibility(): array
+    public static function providerCompatibility(): array
     {
         return [
             [Functions::COMPATIBILITY_EXCEL],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/IndirectTest.php
@@ -54,7 +54,7 @@ class IndirectTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerINDIRECT(): array
+    public static function providerINDIRECT(): array
     {
         return require 'tests/data/Calculation/LookupRef/INDIRECT.php';
     }
@@ -151,7 +151,7 @@ class IndirectTest extends AllSetupTeardown
         self::assertSame($expectedResult, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerRelative(): array
+    public static function providerRelative(): array
     {
         return [
             'same row with bracket next column' => ['c2', 'R[]C[+1]'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/LookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/LookupTest.php
@@ -20,7 +20,7 @@ class LookupTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLOOKUP(): array
+    public static function providerLOOKUP(): array
     {
         return require 'tests/data/Calculation/LookupRef/LOOKUP.php';
     }
@@ -37,7 +37,7 @@ class LookupTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLookupArray(): array
+    public static function providerLookupArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatchTest.php
@@ -77,7 +77,7 @@ class MatchTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerMATCH(): array
+    public static function providerMATCH(): array
     {
         return require 'tests/data/Calculation/LookupRef/MATCH.php';
     }
@@ -94,7 +94,7 @@ class MatchTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerMatchArray(): array
+    public static function providerMatchArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatrixHelperFunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/MatrixHelperFunctionsTest.php
@@ -25,7 +25,7 @@ class MatrixHelperFunctionsTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function columnVectorProvider(): array
+    public static function columnVectorProvider(): array
     {
         return [
             [
@@ -48,7 +48,7 @@ class MatrixHelperFunctionsTest extends TestCase
         ];
     }
 
-    public function rowVectorProvider(): array
+    public static function rowVectorProvider(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/OffsetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/OffsetTest.php
@@ -19,7 +19,7 @@ class OffsetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerOFFSET(): array
+    public static function providerOFFSET(): array
     {
         return require 'tests/data/Calculation/LookupRef/OFFSET.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowOnSpreadsheetTest.php
@@ -36,7 +36,7 @@ class RowOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerROWOnSpreadsheet(): array
+    public static function providerROWOnSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/ROWonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowTest.php
@@ -18,7 +18,7 @@ class RowTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerROW(): array
+    public static function providerROW(): array
     {
         return require 'tests/data/Calculation/LookupRef/ROW.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsOnSpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsOnSpreadsheetTest.php
@@ -36,7 +36,7 @@ class RowsOnSpreadsheetTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerROWSOnSpreadsheet(): array
+    public static function providerROWSOnSpreadsheet(): array
     {
         return require 'tests/data/Calculation/LookupRef/ROWSonSpreadsheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/RowsTest.php
@@ -20,7 +20,7 @@ class RowsTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerROWS(): array
+    public static function providerROWS(): array
     {
         return require 'tests/data/Calculation/LookupRef/ROWS.php';
     }
@@ -37,7 +37,7 @@ class RowsTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerRowsArray(): array
+    public static function providerRowsArray(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/TransposeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/TransposeTest.php
@@ -25,7 +25,7 @@ class TransposeTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerTRANSPOSE(): array
+    public static function providerTRANSPOSE(): array
     {
         return require 'tests/data/Calculation/LookupRef/TRANSPOSE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/UniqueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/UniqueTest.php
@@ -48,7 +48,7 @@ class UniqueTest extends TestCase
         self::assertSame($lookupData, $result);
     }
 
-    public function uniqueTestProvider(): array
+    public static function uniqueTestProvider(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/LookupRef/VLookupTest.php
@@ -41,7 +41,7 @@ class VLookupTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerVLOOKUP(): array
+    public static function providerVLOOKUP(): array
     {
         return require 'tests/data/Calculation/LookupRef/VLOOKUP.php';
     }
@@ -58,7 +58,7 @@ class VLookupTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerVLookupArray(): array
+    public static function providerVLookupArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AbsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AbsTest.php
@@ -26,7 +26,7 @@ class AbsTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerAbs(): array
+    public static function providerAbs(): array
     {
         return require 'tests/data/Calculation/MathTrig/ABS.php';
     }
@@ -43,7 +43,7 @@ class AbsTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAbsArray(): array
+    public static function providerAbsArray(): array
     {
         return [
             'row vector' => [[[1, 0, 1]], '{-1, 0, 1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcosTest.php
@@ -21,7 +21,7 @@ class AcosTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerAcos(): array
+    public static function providerAcos(): array
     {
         return require 'tests/data/Calculation/MathTrig/ACOS.php';
     }
@@ -38,7 +38,7 @@ class AcosTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAcosArray(): array
+    public static function providerAcosArray(): array
     {
         return [
             'row vector' => [[[0.0, 1.04719755119660, 3.14159265358979]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcoshTest.php
@@ -21,7 +21,7 @@ class AcoshTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerAcosh(): array
+    public static function providerAcosh(): array
     {
         return require 'tests/data/Calculation/MathTrig/ACOSH.php';
     }
@@ -38,7 +38,7 @@ class AcoshTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAcoshArray(): array
+    public static function providerAcoshArray(): array
     {
         return [
             'row vector' => [[[0.0, 1.31695789692482, 1.76274717403909]], '{1, 2, 3}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcotTest.php
@@ -25,7 +25,7 @@ class AcotTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerACOT(): array
+    public static function providerACOT(): array
     {
         return require 'tests/data/Calculation/MathTrig/ACOT.php';
     }
@@ -42,7 +42,7 @@ class AcotTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAcotArray(): array
+    public static function providerAcotArray(): array
     {
         return [
             'row vector' => [[[0.78539816339745, 1.10714871779409, 2.35619449019234]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcothTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AcothTest.php
@@ -25,7 +25,7 @@ class AcothTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerACOTH(): array
+    public static function providerACOTH(): array
     {
         return require 'tests/data/Calculation/MathTrig/ACOTH.php';
     }
@@ -42,7 +42,7 @@ class AcothTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAcothArray(): array
+    public static function providerAcothArray(): array
     {
         return [
             'row vector' => [[[-0.20273255405408, 0.54930614433406, 0.13413199329734]], '{-5, 2, 7.5}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ArabicTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ArabicTest.php
@@ -22,7 +22,7 @@ class ArabicTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerARABIC(): array
+    public static function providerARABIC(): array
     {
         return require 'tests/data/Calculation/MathTrig/ARABIC.php';
     }
@@ -39,7 +39,7 @@ class ArabicTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerArabicArray(): array
+    public static function providerArabicArray(): array
     {
         return [
             'row vector' => [[[49, 2022, 499]], '{"XLIX", "MMXXII", "VDIV"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinTest.php
@@ -21,7 +21,7 @@ class AsinTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerAsin(): array
+    public static function providerAsin(): array
     {
         return require 'tests/data/Calculation/MathTrig/ASIN.php';
     }
@@ -38,7 +38,7 @@ class AsinTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAsinArray(): array
+    public static function providerAsinArray(): array
     {
         return [
             'row vector' => [[[1.57079632679490, 0.52359877559830, -1.57079632679490]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AsinhTest.php
@@ -21,7 +21,7 @@ class AsinhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerAsinh(): array
+    public static function providerAsinh(): array
     {
         return require 'tests/data/Calculation/MathTrig/ASINH.php';
     }
@@ -38,7 +38,7 @@ class AsinhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAsinhArray(): array
+    public static function providerAsinhArray(): array
     {
         return [
             'row vector' => [[[0.88137358701954, 0.48121182505960, -0.88137358701954]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Atan2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Atan2Test.php
@@ -22,7 +22,7 @@ class Atan2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerATAN2(): array
+    public static function providerATAN2(): array
     {
         return require 'tests/data/Calculation/MathTrig/ATAN2.php';
     }
@@ -39,7 +39,7 @@ class Atan2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAtan2Array(): array
+    public static function providerAtan2Array(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanTest.php
@@ -21,7 +21,7 @@ class AtanTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerAtan(): array
+    public static function providerAtan(): array
     {
         return require 'tests/data/Calculation/MathTrig/ATAN.php';
     }
@@ -38,7 +38,7 @@ class AtanTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAtanArray(): array
+    public static function providerAtanArray(): array
     {
         return [
             'row vector' => [[[0.78539816339745, 0.46364760900081, -0.78539816339745]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/AtanhTest.php
@@ -21,7 +21,7 @@ class AtanhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerAtanh(): array
+    public static function providerAtanh(): array
     {
         return require 'tests/data/Calculation/MathTrig/ATANH.php';
     }
@@ -38,7 +38,7 @@ class AtanhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerAtanhArray(): array
+    public static function providerAtanhArray(): array
     {
         return [
             'row vector' => [[[1.83178082306482, 0.54930614433406, -1.83178082306482]], '{0.95, 0.5, -0.95}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/BaseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/BaseTest.php
@@ -40,7 +40,7 @@ class BaseTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBASE(): array
+    public static function providerBASE(): array
     {
         return require 'tests/data/Calculation/MathTrig/BASE.php';
     }
@@ -57,7 +57,7 @@ class BaseTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBaseArray(): array
+    public static function providerBaseArray(): array
     {
         return [
             'matrix' => [[['1111111', '177'], ['127', '7F']], '127', '{2, 8; 10, 16}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingMathTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingMathTest.php
@@ -25,7 +25,7 @@ class CeilingMathTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerCEILINGMATH(): array
+    public static function providerCEILINGMATH(): array
     {
         return require 'tests/data/Calculation/MathTrig/CEILINGMATH.php';
     }
@@ -42,7 +42,7 @@ class CeilingMathTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCeilingArray(): array
+    public static function providerCeilingArray(): array
     {
         return [
             'matrix' => [[[3.15, 3.142], [3.1416, 3.141594]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingPreciseTest.php
@@ -25,7 +25,7 @@ class CeilingPreciseTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerFLOORPRECISE(): array
+    public static function providerFLOORPRECISE(): array
     {
         return require 'tests/data/Calculation/MathTrig/CEILINGPRECISE.php';
     }
@@ -42,7 +42,7 @@ class CeilingPreciseTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCeilingArray(): array
+    public static function providerCeilingArray(): array
     {
         return [
             'matrix' => [[[3.15, 3.142], [3.1416, 3.141594]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CeilingTest.php
@@ -25,7 +25,7 @@ class CeilingTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerCEILING(): array
+    public static function providerCEILING(): array
     {
         return require 'tests/data/Calculation/MathTrig/CEILING.php';
     }
@@ -69,7 +69,7 @@ class CeilingTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCeilingArray(): array
+    public static function providerCeilingArray(): array
     {
         return [
             'matrix' => [[[3.15, 3.142], [3.1416, 3.141594]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinATest.php
@@ -28,7 +28,7 @@ class CombinATest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCOMBINA(): array
+    public static function providerCOMBINA(): array
     {
         return require 'tests/data/Calculation/MathTrig/COMBINA.php';
     }
@@ -45,7 +45,7 @@ class CombinATest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCombinAArray(): array
+    public static function providerCombinAArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CombinTest.php
@@ -28,7 +28,7 @@ class CombinTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCOMBIN(): array
+    public static function providerCOMBIN(): array
     {
         return require 'tests/data/Calculation/MathTrig/COMBIN.php';
     }
@@ -45,7 +45,7 @@ class CombinTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCombinArray(): array
+    public static function providerCombinArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CosTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CosTest.php
@@ -21,7 +21,7 @@ class CosTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerCos(): array
+    public static function providerCos(): array
     {
         return require 'tests/data/Calculation/MathTrig/COS.php';
     }
@@ -38,7 +38,7 @@ class CosTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCosArray(): array
+    public static function providerCosArray(): array
     {
         return [
             'row vector' => [[[0.54030230586814, 0.87758256189037, 0.54030230586814]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CoshTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CoshTest.php
@@ -21,7 +21,7 @@ class CoshTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerCosh(): array
+    public static function providerCosh(): array
     {
         return require 'tests/data/Calculation/MathTrig/COSH.php';
     }
@@ -38,7 +38,7 @@ class CoshTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCoshArray(): array
+    public static function providerCoshArray(): array
     {
         return [
             'row vector' => [[[1.54308063481524, 1.12762596520638, 1.54308063481524]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CotTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CotTest.php
@@ -25,7 +25,7 @@ class CotTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerCOT(): array
+    public static function providerCOT(): array
     {
         return require 'tests/data/Calculation/MathTrig/COT.php';
     }
@@ -42,7 +42,7 @@ class CotTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCotArray(): array
+    public static function providerCotArray(): array
     {
         return [
             'row vector' => [[[0.64209261593433, 1.83048772171245, -0.64209261593433]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CothTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CothTest.php
@@ -25,7 +25,7 @@ class CothTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerCOTH(): array
+    public static function providerCOTH(): array
     {
         return require 'tests/data/Calculation/MathTrig/COTH.php';
     }
@@ -42,7 +42,7 @@ class CothTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCothArray(): array
+    public static function providerCothArray(): array
     {
         return [
             'row vector' => [[[1.31303528549933, 2.16395341373865, -1.31303528549933]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CscTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CscTest.php
@@ -25,7 +25,7 @@ class CscTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerCSC(): array
+    public static function providerCSC(): array
     {
         return require 'tests/data/Calculation/MathTrig/CSC.php';
     }
@@ -42,7 +42,7 @@ class CscTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCscArray(): array
+    public static function providerCscArray(): array
     {
         return [
             'row vector' => [[[1.18839510577812, 2.08582964293349, -1.18839510577812]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CschTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/CschTest.php
@@ -25,7 +25,7 @@ class CschTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerCSCH(): array
+    public static function providerCSCH(): array
     {
         return require 'tests/data/Calculation/MathTrig/CSCH.php';
     }
@@ -42,7 +42,7 @@ class CschTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCschArray(): array
+    public static function providerCschArray(): array
     {
         return [
             'row vector' => [[[0.85091812823932, 1.91903475133494, -0.85091812823932]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/DegreesTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/DegreesTest.php
@@ -26,7 +26,7 @@ class DegreesTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 
-    public function providerDegrees(): array
+    public static function providerDegrees(): array
     {
         return require 'tests/data/Calculation/MathTrig/DEGREES.php';
     }
@@ -43,7 +43,7 @@ class DegreesTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
-    public function providerDegreesArray(): array
+    public static function providerDegreesArray(): array
     {
         return [
             'row vector' => [[[143.23944878270600, 7.16197243913529, -183.34649444186300]], '{2.5, 0.125, -3.2}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/EvenTest.php
@@ -21,7 +21,7 @@ class EvenTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $sheet->getCell('A1')->getCalculatedValue());
     }
 
-    public function providerEVEN(): array
+    public static function providerEVEN(): array
     {
         return require 'tests/data/Calculation/MathTrig/EVEN.php';
     }
@@ -38,7 +38,7 @@ class EvenTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerEvenArray(): array
+    public static function providerEvenArray(): array
     {
         return [
             'row vector' => [[[-4, 2, 4]], '{-3, 1, 4}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ExpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ExpTest.php
@@ -28,7 +28,7 @@ class ExpTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerEXP(): array
+    public static function providerEXP(): array
     {
         return require 'tests/data/Calculation/MathTrig/EXP.php';
     }
@@ -45,7 +45,7 @@ class ExpTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerExpArray(): array
+    public static function providerExpArray(): array
     {
         return [
             'row vector' => [[[1.0, 2.718281828459045, 12.182493960703473]], '{0, 1, 2.5}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactDoubleTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactDoubleTest.php
@@ -22,7 +22,7 @@ class FactDoubleTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerFACTDOUBLE(): array
+    public static function providerFACTDOUBLE(): array
     {
         return require 'tests/data/Calculation/MathTrig/FACTDOUBLE.php';
     }
@@ -39,7 +39,7 @@ class FactDoubleTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFactDoubleArray(): array
+    public static function providerFactDoubleArray(): array
     {
         return [
             'row vector' => [[['#NUM!', 48, 945]], '{-2, 6, 9}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FactTest.php
@@ -30,7 +30,7 @@ class FactTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerFACT(): array
+    public static function providerFACT(): array
     {
         return require 'tests/data/Calculation/MathTrig/FACT.php';
     }
@@ -58,7 +58,7 @@ class FactTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, self::FACT_PRECISION);
     }
 
-    public function providerFACTGnumeric(): array
+    public static function providerFACTGnumeric(): array
     {
         return require 'tests/data/Calculation/MathTrig/FACTGNUMERIC.php';
     }
@@ -75,7 +75,7 @@ class FactTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, self::FACT_PRECISION);
     }
 
-    public function providerFactArray(): array
+    public static function providerFactArray(): array
     {
         return [
             'row vector' => [[['#NUM!', 120, 362880]], '{-2, 5, 9}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorMathTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorMathTest.php
@@ -25,7 +25,7 @@ class FloorMathTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerFLOORMATH(): array
+    public static function providerFLOORMATH(): array
     {
         return require 'tests/data/Calculation/MathTrig/FLOORMATH.php';
     }
@@ -42,7 +42,7 @@ class FloorMathTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFloorArray(): array
+    public static function providerFloorArray(): array
     {
         return [
             'matrix' => [[[3.14, 3.14], [3.14155, 3.141592]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorPreciseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorPreciseTest.php
@@ -25,7 +25,7 @@ class FloorPreciseTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerFLOORPRECISE(): array
+    public static function providerFLOORPRECISE(): array
     {
         return require 'tests/data/Calculation/MathTrig/FLOORPRECISE.php';
     }
@@ -42,7 +42,7 @@ class FloorPreciseTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFloorArray(): array
+    public static function providerFloorArray(): array
     {
         return [
             'matrix' => [[[3.14, 3.14], [3.14155, 3.141592]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/FloorTest.php
@@ -25,7 +25,7 @@ class FloorTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerFLOOR(): array
+    public static function providerFLOOR(): array
     {
         return require 'tests/data/Calculation/MathTrig/FLOOR.php';
     }
@@ -69,7 +69,7 @@ class FloorTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFloorArray(): array
+    public static function providerFloorArray(): array
     {
         return [
             'matrix' => [[[3.14, 3.14], [3.14155, 3.141592]], '3.1415926536', '{0.01, 0.002; 0.00005, 0.000002}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/GcdTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/GcdTest.php
@@ -29,7 +29,7 @@ class GcdTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerGCD(): array
+    public static function providerGCD(): array
     {
         return require 'tests/data/Calculation/MathTrig/GCD.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/IntTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/IntTest.php
@@ -25,7 +25,7 @@ class IntTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerINT(): array
+    public static function providerINT(): array
     {
         return require 'tests/data/Calculation/MathTrig/INT.php';
     }
@@ -42,7 +42,7 @@ class IntTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerIntArray(): array
+    public static function providerIntArray(): array
     {
         return [
             'row vector' => [[[-2, 0, 0]], '{-1.5, 0, 0.3}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LcmTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LcmTest.php
@@ -22,7 +22,7 @@ class LcmTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerLCM(): array
+    public static function providerLCM(): array
     {
         return require 'tests/data/Calculation/MathTrig/LCM.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LnTest.php
@@ -28,7 +28,7 @@ class LnTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerLN(): array
+    public static function providerLN(): array
     {
         return require 'tests/data/Calculation/MathTrig/LN.php';
     }
@@ -45,7 +45,7 @@ class LnTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLnArray(): array
+    public static function providerLnArray(): array
     {
         return [
             'row vector' => [[[-2.07944154167984, 0.85228540189824, 2.525728644308256]], '{0.125, 2.345, 12.5}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Log10Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/Log10Test.php
@@ -28,7 +28,7 @@ class Log10Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerLOG10(): array
+    public static function providerLOG10(): array
     {
         return require 'tests/data/Calculation/MathTrig/LOG10.php';
     }
@@ -45,7 +45,7 @@ class Log10Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLog10Array(): array
+    public static function providerLog10Array(): array
     {
         return [
             'row vector' => [[[-0.90308998699194, 0.3701428470511, 1.09691001300806]], '{0.125, 2.345, 12.5}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LogTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/LogTest.php
@@ -34,7 +34,7 @@ class LogTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerLOG(): array
+    public static function providerLOG(): array
     {
         return require 'tests/data/Calculation/MathTrig/LOG.php';
     }
@@ -51,7 +51,7 @@ class LogTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLogArray(): array
+    public static function providerLogArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MInverseTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MInverseTest.php
@@ -17,7 +17,7 @@ class MInverseTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 
-    public function providerMINVERSE(): array
+    public static function providerMINVERSE(): array
     {
         return require 'tests/data/Calculation/MathTrig/MINVERSE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MMultTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MMultTest.php
@@ -17,7 +17,7 @@ class MMultTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 
-    public function providerMMULT(): array
+    public static function providerMMULT(): array
     {
         return require 'tests/data/Calculation/MathTrig/MMULT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MRoundTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MRoundTest.php
@@ -25,7 +25,7 @@ class MRoundTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerMROUND(): array
+    public static function providerMROUND(): array
     {
         return require 'tests/data/Calculation/MathTrig/MROUND.php';
     }
@@ -42,7 +42,7 @@ class MRoundTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerMRoundArray(): array
+    public static function providerMRoundArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MdeTermTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MdeTermTest.php
@@ -26,7 +26,7 @@ class MdeTermTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerMDETERM(): array
+    public static function providerMDETERM(): array
     {
         return require 'tests/data/Calculation/MathTrig/MDETERM.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ModTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ModTest.php
@@ -34,7 +34,7 @@ class ModTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerMOD(): array
+    public static function providerMOD(): array
     {
         return require 'tests/data/Calculation/MathTrig/MOD.php';
     }
@@ -51,7 +51,7 @@ class ModTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerModArray(): array
+    public static function providerModArray(): array
     {
         return [
             'matrix' => [[[4, 3, 2], [1, 0, 4], [3, 2, 1]], '{9, 8, 7; 6, 5, 4; 3, 2, 1}', '5'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MultinomialTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/MultinomialTest.php
@@ -27,7 +27,7 @@ class MultinomialTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerMULTINOMIAL(): array
+    public static function providerMULTINOMIAL(): array
     {
         return require 'tests/data/Calculation/MathTrig/MULTINOMIAL.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/OddTest.php
@@ -21,7 +21,7 @@ class OddTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $sheet->getCell('A1')->getCalculatedValue());
     }
 
-    public function providerODD(): array
+    public static function providerODD(): array
     {
         return require 'tests/data/Calculation/MathTrig/ODD.php';
     }
@@ -38,7 +38,7 @@ class OddTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerOddArray(): array
+    public static function providerOddArray(): array
     {
         return [
             'row vector' => [[[-3, 1, 5]], '{-3, 1, 4}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/PowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/PowerTest.php
@@ -34,7 +34,7 @@ class PowerTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerPOWER(): array
+    public static function providerPOWER(): array
     {
         return require 'tests/data/Calculation/MathTrig/POWER.php';
     }
@@ -51,7 +51,7 @@ class PowerTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerPowerArray(): array
+    public static function providerPowerArray(): array
     {
         return [
             'matrix' => [[[729, 512, 343], [216, 125, 64], [27, 8, 1]], '{9, 8, 7; 6, 5, 4; 3, 2, 1}', '3'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/ProductTest.php
@@ -22,7 +22,7 @@ class ProductTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerPRODUCT(): array
+    public static function providerPRODUCT(): array
     {
         return require 'tests/data/Calculation/MathTrig/PRODUCT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/QuotientTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/QuotientTest.php
@@ -34,7 +34,7 @@ class QuotientTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerQUOTIENT(): array
+    public static function providerQUOTIENT(): array
     {
         return require 'tests/data/Calculation/MathTrig/QUOTIENT.php';
     }
@@ -51,7 +51,7 @@ class QuotientTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerQuotientArray(): array
+    public static function providerQuotientArray(): array
     {
         return [
             'matrix' => [[[3, 3, 2], [2, 2, 1], [1, 0, 0]], '{9, 8, 7; 6, 5, 4; 3, 2, 1}', '2.5'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RadiansTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RadiansTest.php
@@ -26,7 +26,7 @@ class RadiansTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerRADIANS(): array
+    public static function providerRADIANS(): array
     {
         return require 'tests/data/Calculation/MathTrig/RADIANS.php';
     }
@@ -43,7 +43,7 @@ class RadiansTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerRadiansArray(): array
+    public static function providerRadiansArray(): array
     {
         return [
             'row vector' => [[[1.48352986419518, 3.92699081698724, -0.26179938779915]], '{85, 225, -15}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RandBetweenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RandBetweenTest.php
@@ -41,7 +41,7 @@ class RandBetweenTest extends AllSetupTeardown
         }
     }
 
-    public function providerRANDBETWEEN(): array
+    public static function providerRANDBETWEEN(): array
     {
         return require 'tests/data/Calculation/MathTrig/RANDBETWEEN.php';
     }
@@ -65,7 +65,7 @@ class RandBetweenTest extends AllSetupTeardown
         self::assertCount($expectedColumns, /** @scrutinizer ignore-type */ $result[0]);
     }
 
-    public function providerRandBetweenArray(): array
+    public static function providerRandBetweenArray(): array
     {
         return [
             'row/column vectors' => [2, 2, '{1, 10}', '{10; 100}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RomanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RomanTest.php
@@ -22,7 +22,7 @@ class RomanTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerROMAN(): array
+    public static function providerROMAN(): array
     {
         return require 'tests/data/Calculation/MathTrig/ROMAN.php';
     }
@@ -39,7 +39,7 @@ class RomanTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerRomanArray(): array
+    public static function providerRomanArray(): array
     {
         return [
             'row vector' => [[['XLIX', 'MMXXII', 'CDXCIX']], '{49, 2022, 499}', '0'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundDownTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundDownTest.php
@@ -25,7 +25,7 @@ class RoundDownTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerRoundDown(): array
+    public static function providerRoundDown(): array
     {
         return require 'tests/data/Calculation/MathTrig/ROUNDDOWN.php';
     }
@@ -42,7 +42,7 @@ class RoundDownTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerRoundDownArray(): array
+    public static function providerRoundDownArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundTest.php
@@ -25,7 +25,7 @@ class RoundTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerRound(): array
+    public static function providerRound(): array
     {
         return require 'tests/data/Calculation/MathTrig/ROUND.php';
     }
@@ -42,7 +42,7 @@ class RoundTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerRoundArray(): array
+    public static function providerRoundArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundUpTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/RoundUpTest.php
@@ -25,7 +25,7 @@ class RoundUpTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerRoundUp(): array
+    public static function providerRoundUp(): array
     {
         return require 'tests/data/Calculation/MathTrig/ROUNDUP.php';
     }
@@ -42,7 +42,7 @@ class RoundUpTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerRoundUpArray(): array
+    public static function providerRoundUpArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SecTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SecTest.php
@@ -25,7 +25,7 @@ class SecTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerSEC(): array
+    public static function providerSEC(): array
     {
         return require 'tests/data/Calculation/MathTrig/SEC.php';
     }
@@ -42,7 +42,7 @@ class SecTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSecArray(): array
+    public static function providerSecArray(): array
     {
         return [
             'row vector' => [[[1.85081571768093, 1.13949392732455, 1.85081571768093]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SechTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SechTest.php
@@ -25,7 +25,7 @@ class SechTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-9);
     }
 
-    public function providerSECH(): array
+    public static function providerSECH(): array
     {
         return require 'tests/data/Calculation/MathTrig/SECH.php';
     }
@@ -42,7 +42,7 @@ class SechTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSechArray(): array
+    public static function providerSechArray(): array
     {
         return [
             'row vector' => [[[0.64805427366389, 0.88681888397007, 0.64805427366389]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SequenceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SequenceTest.php
@@ -28,7 +28,7 @@ class SequenceTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerSEQUENCE(): array
+    public static function providerSEQUENCE(): array
     {
         return require 'tests/data/Calculation/MathTrig/SEQUENCE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SeriesSumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SeriesSumTest.php
@@ -40,7 +40,7 @@ class SeriesSumTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSERIESSUM(): array
+    public static function providerSERIESSUM(): array
     {
         return require 'tests/data/Calculation/MathTrig/SERIESSUM.php';
     }
@@ -57,7 +57,7 @@ class SeriesSumTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSeriesSumArray(): array
+    public static function providerSeriesSumArray(): array
     {
         return [
             'row vector #1' => [[[3780, 756]], '5', '{1, 0}', '1', '{1, 1, 0, 1, 1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SignTest.php
@@ -24,7 +24,7 @@ class SignTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerSIGN(): array
+    public static function providerSIGN(): array
     {
         return require 'tests/data/Calculation/MathTrig/SIGN.php';
     }
@@ -41,7 +41,7 @@ class SignTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSignArray(): array
+    public static function providerSignArray(): array
     {
         return [
             'row vector' => [[[-1, 0, 1]], '{-1.5, 0, 0.3}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinTest.php
@@ -21,7 +21,7 @@ class SinTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerSin(): array
+    public static function providerSin(): array
     {
         return require 'tests/data/Calculation/MathTrig/SIN.php';
     }
@@ -38,7 +38,7 @@ class SinTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSinArray(): array
+    public static function providerSinArray(): array
     {
         return [
             'row vector' => [[[0.84147098480790, 0.47942553860420, -0.84147098480790]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SinhTest.php
@@ -21,7 +21,7 @@ class SinhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerCosh(): array
+    public static function providerCosh(): array
     {
         return require 'tests/data/Calculation/MathTrig/SINH.php';
     }
@@ -38,7 +38,7 @@ class SinhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSinhArray(): array
+    public static function providerSinhArray(): array
     {
         return [
             'row vector' => [[[1.17520119364380, 0.52109530549375, -1.17520119364380]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtPiTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtPiTest.php
@@ -28,7 +28,7 @@ class SqrtPiTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSQRTPI(): array
+    public static function providerSQRTPI(): array
     {
         return require 'tests/data/Calculation/MathTrig/SQRTPI.php';
     }
@@ -45,7 +45,7 @@ class SqrtPiTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
-    public function providerSqrtPiArray(): array
+    public static function providerSqrtPiArray(): array
     {
         return [
             'row vector' => [[[5.317361552716, 6.2665706865775, 8.6832150546992]], '{9, 12.5, 24}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SqrtTest.php
@@ -26,7 +26,7 @@ class SqrtTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerSqrt(): array
+    public static function providerSqrt(): array
     {
         return require 'tests/data/Calculation/MathTrig/SQRT.php';
     }
@@ -43,7 +43,7 @@ class SqrtTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSqrtArray(): array
+    public static function providerSqrtArray(): array
     {
         return [
             'row vector' => [[[3, 3.5355339059327378, 4.898979485566356]], '{9, 12.5, 24}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SubTotalTest.php
@@ -22,7 +22,7 @@ class SubTotalTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUBTOTAL(): array
+    public static function providerSUBTOTAL(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUBTOTAL.php';
     }
@@ -100,7 +100,7 @@ class SubTotalTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUBTOTALHIDDEN(): array
+    public static function providerSUBTOTALHIDDEN(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUBTOTALHIDDEN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumIfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumIfTest.php
@@ -34,7 +34,7 @@ class SumIfTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMIF(): array
+    public static function providerSUMIF(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMIF.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumIfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumIfsTest.php
@@ -17,7 +17,7 @@ class SumIfsTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMIFS(): array
+    public static function providerSUMIFS(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMIFS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumProductTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumProductTest.php
@@ -34,7 +34,7 @@ class SumProductTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMPRODUCT(): array
+    public static function providerSUMPRODUCT(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMPRODUCT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumSqTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumSqTest.php
@@ -27,7 +27,7 @@ class SumSqTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMSQ(): array
+    public static function providerSUMSQ(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMSQ.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumTest.php
@@ -24,7 +24,7 @@ class SumTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUM(): array
+    public static function providerSUM(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUM.php';
     }
@@ -42,7 +42,7 @@ class SumTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMLiterals(): array
+    public static function providerSUMLiterals(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMLITERALS.php';
     }
@@ -75,7 +75,7 @@ class SumTest extends AllSetupTeardown
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerSUMWITHINDEXMATCH(): array
+    public static function providerSUMWITHINDEXMATCH(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMWITHINDEXMATCH.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumX2MY2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumX2MY2Test.php
@@ -34,7 +34,7 @@ class SumX2MY2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMX2MY2(): array
+    public static function providerSUMX2MY2(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMX2MY2.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumX2PY2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumX2PY2Test.php
@@ -34,7 +34,7 @@ class SumX2PY2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMX2PY2(): array
+    public static function providerSUMX2PY2(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMX2PY2.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumXMY2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/SumXMY2Test.php
@@ -34,7 +34,7 @@ class SumXMY2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerSUMXMY2(): array
+    public static function providerSUMXMY2(): array
     {
         return require 'tests/data/Calculation/MathTrig/SUMXMY2.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanTest.php
@@ -21,7 +21,7 @@ class TanTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerTan(): array
+    public static function providerTan(): array
     {
         return require 'tests/data/Calculation/MathTrig/TAN.php';
     }
@@ -38,7 +38,7 @@ class TanTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTanArray(): array
+    public static function providerTanArray(): array
     {
         return [
             'row vector' => [[[1.55740772465490, 0.54630248984379, -1.55740772465490]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanhTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TanhTest.php
@@ -21,7 +21,7 @@ class TanhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-6);
     }
 
-    public function providerTanh(): array
+    public static function providerTanh(): array
     {
         return require 'tests/data/Calculation/MathTrig/TANH.php';
     }
@@ -38,7 +38,7 @@ class TanhTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTanhArray(): array
+    public static function providerTanhArray(): array
     {
         return [
             'row vector' => [[[0.76159415595577, 0.46211715726001, -0.76159415595577]], '{1, 0.5, -1}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/MathTrig/TruncTest.php
@@ -25,7 +25,7 @@ class TruncTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerTRUNC(): array
+    public static function providerTRUNC(): array
     {
         return require 'tests/data/Calculation/MathTrig/TRUNC.php';
     }
@@ -42,7 +42,7 @@ class TruncTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTruncArray(): array
+    public static function providerTruncArray(): array
     {
         return [
             'matrix' => [[[3.14, 3.141], [3.14159, 3.14159265]], '3.1415926536', '{2, 3; 5, 8}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AveDevTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AveDevTest.php
@@ -14,7 +14,7 @@ class AveDevTest extends AllSetupTeardown
         $this->runTestCases('AVEDEV', $expectedResult, ...$args);
     }
 
-    public function providerAVEDEV(): array
+    public static function providerAVEDEV(): array
     {
         return require 'tests/data/Calculation/Statistical/AVEDEV.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageATest.php
@@ -14,7 +14,7 @@ class AverageATest extends AllSetupTeardown
         $this->runTestCases('AVERAGEA', $expectedResult, ...$args);
     }
 
-    public function providerAVERAGEA(): array
+    public static function providerAVERAGEA(): array
     {
         return require 'tests/data/Calculation/Statistical/AVERAGEA.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageIfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageIfTest.php
@@ -16,7 +16,7 @@ class AverageIfTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('AVERAGEIF', $expectedResult, ...$args);
     }
 
-    public function providerAVERAGEIF(): array
+    public static function providerAVERAGEIF(): array
     {
         return require 'tests/data/Calculation/Statistical/AVERAGEIF.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageIfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageIfsTest.php
@@ -16,7 +16,7 @@ class AverageIfsTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('AVERAGEIFS', $expectedResult, ...$args);
     }
 
-    public function providerAVERAGEIFS(): array
+    public static function providerAVERAGEIFS(): array
     {
         return require 'tests/data/Calculation/Statistical/AVERAGEIFS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/AverageTest.php
@@ -14,7 +14,7 @@ class AverageTest extends AllSetupTeardown
         $this->runTestCases('AVERAGE', $expectedResult, ...$args);
     }
 
-    public function providerAVERAGE(): array
+    public static function providerAVERAGE(): array
     {
         return require 'tests/data/Calculation/Statistical/AVERAGE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaDistTest.php
@@ -16,7 +16,7 @@ class BetaDistTest extends AllSetupTeardown
         $this->runTestCaseReference('BETADIST', $expectedResult, ...$args);
     }
 
-    public function providerBETADIST(): array
+    public static function providerBETADIST(): array
     {
         return require 'tests/data/Calculation/Statistical/BETADIST.php';
     }
@@ -33,7 +33,7 @@ class BetaDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBetaDistArray(): array
+    public static function providerBetaDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BetaInvTest.php
@@ -16,7 +16,7 @@ class BetaInvTest extends AllSetupTeardown
         $this->runTestCaseReference('BETAINV', $expectedResult, ...$args);
     }
 
-    public function providerBETAINV(): array
+    public static function providerBETAINV(): array
     {
         return require 'tests/data/Calculation/Statistical/BETAINV.php';
     }
@@ -33,7 +33,7 @@ class BetaInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBetaInvArray(): array
+    public static function providerBetaInvArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistRangeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistRangeTest.php
@@ -16,7 +16,7 @@ class BinomDistRangeTest extends AllSetupTeardown
         $this->runTestCaseReference('BINOM.DIST.RANGE', $expectedResult, ...$args);
     }
 
-    public function providerBINOMDISTRANGE(): array
+    public static function providerBINOMDISTRANGE(): array
     {
         return require 'tests/data/Calculation/Statistical/BINOMDISTRANGE.php';
     }
@@ -37,7 +37,7 @@ class BinomDistRangeTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBinomDistRangeArray(): array
+    public static function providerBinomDistRangeArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomDistTest.php
@@ -16,7 +16,7 @@ class BinomDistTest extends AllSetupTeardown
         $this->runTestCaseReference('BINOMDIST', $expectedResult, ...$args);
     }
 
-    public function providerBINOMDIST(): array
+    public static function providerBINOMDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/BINOMDIST.php';
     }
@@ -37,7 +37,7 @@ class BinomDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBinomDistArray(): array
+    public static function providerBinomDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/BinomInvTest.php
@@ -16,7 +16,7 @@ class BinomInvTest extends AllSetupTeardown
         $this->runTestCaseReference('BINOM.INV', $expectedResult, ...$args);
     }
 
-    public function providerBINOMINV(): array
+    public static function providerBINOMINV(): array
     {
         return require 'tests/data/Calculation/Statistical/BINOMINV.php';
     }
@@ -37,7 +37,7 @@ class BinomInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerBinomInvArray(): array
+    public static function providerBinomInvArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistLeftTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistLeftTailTest.php
@@ -16,7 +16,7 @@ class ChiDistLeftTailTest extends AllSetupTeardown
         $this->runTestCaseReference('CHISQ.DIST', $expectedResult, ...$args);
     }
 
-    public function providerCHIDIST(): array
+    public static function providerCHIDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/CHIDISTLeftTail.php';
     }
@@ -33,7 +33,7 @@ class ChiDistLeftTailTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerChiDistLeftTailArray(): array
+    public static function providerChiDistLeftTailArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistRightTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiDistRightTailTest.php
@@ -16,7 +16,7 @@ class ChiDistRightTailTest extends AllSetupTeardown
         $this->runTestCaseReference('CHISQ.DIST.RT', $expectedResult, ...$args);
     }
 
-    public function providerCHIDIST(): array
+    public static function providerCHIDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/CHIDISTRightTail.php';
     }
@@ -33,7 +33,7 @@ class ChiDistRightTailTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerChiDistRightTailArray(): array
+    public static function providerChiDistRightTailArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvLeftTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvLeftTailTest.php
@@ -16,7 +16,7 @@ class ChiInvLeftTailTest extends AllSetupTeardown
         $this->runTestCaseReference('CHISQ.INV', $expectedResult, ...$args);
     }
 
-    public function providerCHIINV(): array
+    public static function providerCHIINV(): array
     {
         return require 'tests/data/Calculation/Statistical/CHIINVLeftTail.php';
     }
@@ -47,7 +47,7 @@ class ChiInvLeftTailTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerChiInvLeftTailArray(): array
+    public static function providerChiInvLeftTailArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvRightTailTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiInvRightTailTest.php
@@ -16,7 +16,7 @@ class ChiInvRightTailTest extends AllSetupTeardown
         $this->runTestCases('CHISQ.INV.RT', $expectedResult, ...$args);
     }
 
-    public function providerCHIINV(): array
+    public static function providerCHIINV(): array
     {
         return require 'tests/data/Calculation/Statistical/CHIINVRightTail.php';
     }
@@ -47,7 +47,7 @@ class ChiInvRightTailTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerChiInvRightTailArray(): array
+    public static function providerChiInvRightTailArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiTestTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ChiTestTest.php
@@ -21,7 +21,7 @@ class ChiTestTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerCHITEST(): array
+    public static function providerCHITEST(): array
     {
         return require 'tests/data/Calculation/Statistical/CHITEST.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ConfidenceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ConfidenceTest.php
@@ -16,7 +16,7 @@ class ConfidenceTest extends AllSetupTeardown
         $this->runTestCaseReference('CONFIDENCE', $expectedResult, ...$args);
     }
 
-    public function providerCONFIDENCE(): array
+    public static function providerCONFIDENCE(): array
     {
         return require 'tests/data/Calculation/Statistical/CONFIDENCE.php';
     }
@@ -33,7 +33,7 @@ class ConfidenceTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerConfidenceArray(): array
+    public static function providerConfidenceArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CorrelTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CorrelTest.php
@@ -20,7 +20,7 @@ class CorrelTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerCORREL(): array
+    public static function providerCORREL(): array
     {
         return require 'tests/data/Calculation/Statistical/CORREL.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountATest.php
@@ -14,7 +14,7 @@ class CountATest extends AllSetupTeardown
         $this->runTestCases('COUNTA', $expectedResult, ...$args);
     }
 
-    public function providerCOUNTA(): array
+    public static function providerCOUNTA(): array
     {
         return require 'tests/data/Calculation/Statistical/COUNTA.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountBlankTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountBlankTest.php
@@ -16,7 +16,7 @@ class CountBlankTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('COUNTBLANK', $expectedResult, ...$args);
     }
 
-    public function providerCOUNTBLANK(): array
+    public static function providerCOUNTBLANK(): array
     {
         return require 'tests/data/Calculation/Statistical/COUNTBLANK.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountIfTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountIfTest.php
@@ -25,7 +25,7 @@ class CountIfTest extends AllSetupTeardown
         self::assertSame(4, $sheet->getCell('Z99')->getCalculatedValue());
     }
 
-    public function providerCOUNTIF(): array
+    public static function providerCOUNTIF(): array
     {
         return require 'tests/data/Calculation/Statistical/COUNTIF.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountIfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountIfsTest.php
@@ -15,7 +15,7 @@ class CountIfsTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('COUNTIFS', $expectedResult, ...$args);
     }
 
-    public function providerCOUNTIFS(): array
+    public static function providerCOUNTIFS(): array
     {
         return require 'tests/data/Calculation/Statistical/COUNTIFS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CountTest.php
@@ -14,7 +14,7 @@ class CountTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('COUNT', $expectedResult, ...$args);
     }
 
-    public function providerBasicCOUNT(): array
+    public static function providerBasicCOUNT(): array
     {
         return require 'tests/data/Calculation/Statistical/BasicCOUNT.php';
     }
@@ -33,7 +33,7 @@ class CountTest extends AllSetupTeardown
         }
     }
 
-    public function providerExcelCOUNT(): array
+    public static function providerExcelCOUNT(): array
     {
         return require 'tests/data/Calculation/Statistical/ExcelCOUNT.php';
     }
@@ -53,7 +53,7 @@ class CountTest extends AllSetupTeardown
         }
     }
 
-    public function providerOpenOfficeCOUNT(): array
+    public static function providerOpenOfficeCOUNT(): array
     {
         return require 'tests/data/Calculation/Statistical/OpenOfficeCOUNT.php';
     }
@@ -69,7 +69,7 @@ class CountTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('COUNT', $expectedResult, ...$args);
     }
 
-    public function providerGnumericCOUNT(): array
+    public static function providerGnumericCOUNT(): array
     {
         return require 'tests/data/Calculation/Statistical/GnumericCOUNT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CovarTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/CovarTest.php
@@ -14,7 +14,7 @@ class CovarTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('COVAR', $expectedResult, ...$args);
     }
 
-    public function providerCOVAR(): array
+    public static function providerCOVAR(): array
     {
         return require 'tests/data/Calculation/Statistical/COVAR.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/DevSqTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/DevSqTest.php
@@ -14,7 +14,7 @@ class DevSqTest extends AllSetupTeardown
         $this->runTestCases('DEVSQ', $expectedResult, ...$args);
     }
 
-    public function providerDEVSQ(): array
+    public static function providerDEVSQ(): array
     {
         return require 'tests/data/Calculation/Statistical/DEVSQ.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ExponDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ExponDistTest.php
@@ -16,7 +16,7 @@ class ExponDistTest extends AllSetupTeardown
         $this->runTestCases('EXPONDIST', $expectedResult, ...$args);
     }
 
-    public function providerEXPONDIST(): array
+    public static function providerEXPONDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/EXPONDIST.php';
     }
@@ -33,7 +33,7 @@ class ExponDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerExponDistArray(): array
+    public static function providerExponDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FDistTest.php
@@ -16,7 +16,7 @@ class FDistTest extends AllSetupTeardown
         $this->runTestCases('F.DIST', $expectedResult, ...$args);
     }
 
-    public function providerFDIST(): array
+    public static function providerFDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/FDIST.php';
     }
@@ -33,7 +33,7 @@ class FDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFDistArray(): array
+    public static function providerFDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherInvTest.php
@@ -16,7 +16,7 @@ class FisherInvTest extends AllSetupTeardown
         $this->runTestCases('FISHERINV', $expectedResult, ...$args);
     }
 
-    public function providerFISHERINV(): array
+    public static function providerFISHERINV(): array
     {
         return require 'tests/data/Calculation/Statistical/FISHERINV.php';
     }
@@ -33,7 +33,7 @@ class FisherInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFisherArray(): array
+    public static function providerFisherArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/FisherTest.php
@@ -16,7 +16,7 @@ class FisherTest extends AllSetupTeardown
         $this->runTestCases('FISHER', $expectedResult, ...$args);
     }
 
-    public function providerFISHER(): array
+    public static function providerFISHER(): array
     {
         return require 'tests/data/Calculation/Statistical/FISHER.php';
     }
@@ -33,7 +33,7 @@ class FisherTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFisherArray(): array
+    public static function providerFisherArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ForecastTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ForecastTest.php
@@ -21,7 +21,7 @@ class ForecastTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-12);
     }
 
-    public function providerFORECAST(): array
+    public static function providerFORECAST(): array
     {
         return require 'tests/data/Calculation/Statistical/FORECAST.php';
     }
@@ -38,7 +38,7 @@ class ForecastTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerForecastArray(): array
+    public static function providerForecastArray(): array
     {
         return [
             'row vector' => [[[-11.047619047619047, 22.95238095238095, 42.38095238095237]], '{-2, 5, 9}', '{3, 7, 15, 20, 22, 27}', '{1, 2, 3, 4, 5, 6}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaDistTest.php
@@ -16,7 +16,7 @@ class GammaDistTest extends AllSetupTeardown
         $this->runTestCases('GAMMA.DIST', $expectedResult, ...$args);
     }
 
-    public function providerGAMMADIST(): array
+    public static function providerGAMMADIST(): array
     {
         return require 'tests/data/Calculation/Statistical/GAMMADIST.php';
     }
@@ -33,7 +33,7 @@ class GammaDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerGammaDistArray(): array
+    public static function providerGammaDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaInvTest.php
@@ -16,7 +16,7 @@ class GammaInvTest extends AllSetupTeardown
         $this->runTestCases('GAMMA.INV', $expectedResult, ...$args);
     }
 
-    public function providerGAMMAINV(): array
+    public static function providerGAMMAINV(): array
     {
         return require 'tests/data/Calculation/Statistical/GAMMAINV.php';
     }
@@ -33,7 +33,7 @@ class GammaInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerGammaInvArray(): array
+    public static function providerGammaInvArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaLnTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaLnTest.php
@@ -16,7 +16,7 @@ class GammaLnTest extends AllSetupTeardown
         $this->runTestCases('GAMMALN', $expectedResult, ...$args);
     }
 
-    public function providerGAMMALN(): array
+    public static function providerGAMMALN(): array
     {
         return require 'tests/data/Calculation/Statistical/GAMMALN.php';
     }
@@ -33,7 +33,7 @@ class GammaLnTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerGammaLnArray(): array
+    public static function providerGammaLnArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GammaTest.php
@@ -16,7 +16,7 @@ class GammaTest extends AllSetupTeardown
         $this->runTestCases('GAMMA', $expectedResult, ...$args);
     }
 
-    public function providerGAMMA(): array
+    public static function providerGAMMA(): array
     {
         return require 'tests/data/Calculation/Statistical/GAMMA.php';
     }
@@ -33,7 +33,7 @@ class GammaTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerGammaArray(): array
+    public static function providerGammaArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GaussTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GaussTest.php
@@ -16,7 +16,7 @@ class GaussTest extends AllSetupTeardown
         $this->runTestCases('GAUSS', $expectedResult, ...$args);
     }
 
-    public function providerGAUSS(): array
+    public static function providerGAUSS(): array
     {
         return require 'tests/data/Calculation/Statistical/GAUSS.php';
     }
@@ -33,7 +33,7 @@ class GaussTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerGaussArray(): array
+    public static function providerGaussArray(): array
     {
         return [
             'matrix' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GeoMeanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GeoMeanTest.php
@@ -14,7 +14,7 @@ class GeoMeanTest extends AllSetupTeardown
         $this->runTestCases('GEOMEAN', $expectedResult, ...$args);
     }
 
-    public function providerGEOMEAN(): array
+    public static function providerGEOMEAN(): array
     {
         return require 'tests/data/Calculation/Statistical/GEOMEAN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GrowthTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/GrowthTest.php
@@ -26,7 +26,7 @@ class GrowthTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result[0], 1E-12);
     }
 
-    public function providerGROWTH(): array
+    public static function providerGROWTH(): array
     {
         return require 'tests/data/Calculation/Statistical/GROWTH.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/HarMeanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/HarMeanTest.php
@@ -14,7 +14,7 @@ class HarMeanTest extends AllSetupTeardown
         $this->runTestCases('HARMEAN', $expectedResult, ...$args);
     }
 
-    public function providerHARMEAN(): array
+    public static function providerHARMEAN(): array
     {
         return require 'tests/data/Calculation/Statistical/HARMEAN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/HypGeomDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/HypGeomDistTest.php
@@ -16,7 +16,7 @@ class HypGeomDistTest extends AllSetupTeardown
         $this->runTestCases('HYPGEOMDIST', $expectedResult, ...$args);
     }
 
-    public function providerHYPGEOMDIST(): array
+    public static function providerHYPGEOMDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/HYPGEOMDIST.php';
     }
@@ -38,7 +38,7 @@ class HypGeomDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerHypGeomDistArray(): array
+    public static function providerHypGeomDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/InterceptTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/InterceptTest.php
@@ -14,7 +14,7 @@ class InterceptTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('INTERCEPT', $expectedResult, ...$args);
     }
 
-    public function providerINTERCEPT(): array
+    public static function providerINTERCEPT(): array
     {
         return require 'tests/data/Calculation/Statistical/INTERCEPT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/KurtTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/KurtTest.php
@@ -14,7 +14,7 @@ class KurtTest extends AllSetupTeardown
         $this->runTestCases('KURT', $expectedResult, ...$args);
     }
 
-    public function providerKURT(): array
+    public static function providerKURT(): array
     {
         return require 'tests/data/Calculation/Statistical/KURT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LargeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LargeTest.php
@@ -14,7 +14,7 @@ class LargeTest extends AllSetupTeardown
         $this->runTestCaseReference('LARGE', $expectedResult, ...$args);
     }
 
-    public function providerLARGE(): array
+    public static function providerLARGE(): array
     {
         return require 'tests/data/Calculation/Statistical/LARGE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LinEstTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LinEstTest.php
@@ -27,7 +27,7 @@ class LinEstTest extends TestCase
         }
     }
 
-    public function providerLINEST(): array
+    public static function providerLINEST(): array
     {
         return require 'tests/data/Calculation/Statistical/LINEST.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogEstTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogEstTest.php
@@ -27,7 +27,7 @@ class LogEstTest extends TestCase
         }
     }
 
-    public function providerLOGEST(): array
+    public static function providerLOGEST(): array
     {
         return require 'tests/data/Calculation/Statistical/LOGEST.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogInvTest.php
@@ -16,7 +16,7 @@ class LogInvTest extends AllSetupTeardown
         $this->runTestCases('LOGINV', $expectedResult, ...$args);
     }
 
-    public function providerLOGINV(): array
+    public static function providerLOGINV(): array
     {
         return require 'tests/data/Calculation/Statistical/LOGINV.php';
     }
@@ -33,7 +33,7 @@ class LogInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLogInvArray(): array
+    public static function providerLogInvArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDist2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDist2Test.php
@@ -16,7 +16,7 @@ class LogNormDist2Test extends AllSetupTeardown
         $this->runTestCases('LOGNORM.DIST', $expectedResult, ...$args);
     }
 
-    public function providerLOGNORMDIST2(): array
+    public static function providerLOGNORMDIST2(): array
     {
         return require 'tests/data/Calculation/Statistical/LOGNORMDIST2.php';
     }
@@ -33,7 +33,7 @@ class LogNormDist2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLogNormDist2Array(): array
+    public static function providerLogNormDist2Array(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/LogNormDistTest.php
@@ -16,7 +16,7 @@ class LogNormDistTest extends AllSetupTeardown
         $this->runTestCases('LOGNORMDIST', $expectedResult, ...$args);
     }
 
-    public function providerLOGNORMDIST(): array
+    public static function providerLOGNORMDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/LOGNORMDIST.php';
     }
@@ -33,7 +33,7 @@ class LogNormDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLogNormDistArray(): array
+    public static function providerLogNormDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MaxATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MaxATest.php
@@ -14,7 +14,7 @@ class MaxATest extends AllSetupTeardown
         $this->runTestCaseReference('MAXA', $expectedResult, ...$args);
     }
 
-    public function providerMAXA(): array
+    public static function providerMAXA(): array
     {
         return require 'tests/data/Calculation/Statistical/MAXA.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MaxIfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MaxIfsTest.php
@@ -14,7 +14,7 @@ class MaxIfsTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('MAXIFS', $expectedResult, ...$args);
     }
 
-    public function providerMAXIFS(): array
+    public static function providerMAXIFS(): array
     {
         return require 'tests/data/Calculation/Statistical/MAXIFS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MaxTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MaxTest.php
@@ -14,7 +14,7 @@ class MaxTest extends AllSetupTeardown
         $this->runTestCaseReference('MAX', $expectedResult, ...$args);
     }
 
-    public function providerMAX(): array
+    public static function providerMAX(): array
     {
         return require 'tests/data/Calculation/Statistical/MAX.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MedianTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MedianTest.php
@@ -14,7 +14,7 @@ class MedianTest extends AllSetupTeardown
         $this->runTestCases('MEDIAN', $expectedResult, ...$args);
     }
 
-    public function providerMEDIAN(): array
+    public static function providerMEDIAN(): array
     {
         return require 'tests/data/Calculation/Statistical/MEDIAN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MinATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MinATest.php
@@ -14,7 +14,7 @@ class MinATest extends AllSetupTeardown
         $this->runTestCaseReference('MINA', $expectedResult, ...$args);
     }
 
-    public function providerMINA(): array
+    public static function providerMINA(): array
     {
         return require 'tests/data/Calculation/Statistical/MINA.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MinIfsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MinIfsTest.php
@@ -14,7 +14,7 @@ class MinIfsTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('MINIFS', $expectedResult, ...$args);
     }
 
-    public function providerMINIFS(): array
+    public static function providerMINIFS(): array
     {
         return require 'tests/data/Calculation/Statistical/MINIFS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/MinTest.php
@@ -14,7 +14,7 @@ class MinTest extends AllSetupTeardown
         $this->runTestCaseReference('MIN', $expectedResult, ...$args);
     }
 
-    public function providerMIN(): array
+    public static function providerMIN(): array
     {
         return require 'tests/data/Calculation/Statistical/MIN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ModeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ModeTest.php
@@ -24,7 +24,7 @@ class ModeTest extends TestCase
         self::assertEquals($expectedResult, $sheet->getCell("C$row")->getCalculatedValue());
     }
 
-    public function providerMODE(): array
+    public static function providerMODE(): array
     {
         return require 'tests/data/Calculation/Statistical/MODE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NegBinomDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NegBinomDistTest.php
@@ -16,7 +16,7 @@ class NegBinomDistTest extends AllSetupTeardown
         $this->runTestCases('NEGBINOMDIST', $expectedResult, ...$args);
     }
 
-    public function providerNEGBINOMDIST(): array
+    public static function providerNEGBINOMDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/NEGBINOMDIST.php';
     }
@@ -37,7 +37,7 @@ class NegBinomDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNegBinomDistArray(): array
+    public static function providerNegBinomDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormDistTest.php
@@ -16,7 +16,7 @@ class NormDistTest extends AllSetupTeardown
         $this->runTestCases('NORMDIST', $expectedResult, ...$args);
     }
 
-    public function providerNORMDIST(): array
+    public static function providerNORMDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/NORMDIST.php';
     }
@@ -33,7 +33,7 @@ class NormDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNormDistArray(): array
+    public static function providerNormDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormInvTest.php
@@ -16,7 +16,7 @@ class NormInvTest extends AllSetupTeardown
         $this->runTestCases('NORMINV', $expectedResult, ...$args);
     }
 
-    public function providerNORMINV(): array
+    public static function providerNORMINV(): array
     {
         return require 'tests/data/Calculation/Statistical/NORMINV.php';
     }
@@ -33,7 +33,7 @@ class NormInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNormInvArray(): array
+    public static function providerNormInvArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDist2Test.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDist2Test.php
@@ -16,7 +16,7 @@ class NormSDist2Test extends AllSetupTeardown
         $this->runTestCases('NORM.S.DIST', $expectedResult, ...$args);
     }
 
-    public function providerNORMSDIST2(): array
+    public static function providerNORMSDIST2(): array
     {
         return require 'tests/data/Calculation/Statistical/NORMSDIST2.php';
     }
@@ -33,7 +33,7 @@ class NormSDist2Test extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNormSDist2Array(): array
+    public static function providerNormSDist2Array(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSDistTest.php
@@ -16,7 +16,7 @@ class NormSDistTest extends AllSetupTeardown
         $this->runTestCases('NORMSDIST', $expectedResult, ...$args);
     }
 
-    public function providerNORMSDIST(): array
+    public static function providerNORMSDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/NORMSDIST.php';
     }
@@ -33,7 +33,7 @@ class NormSDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNormSDistArray(): array
+    public static function providerNormSDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSInvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/NormSInvTest.php
@@ -16,7 +16,7 @@ class NormSInvTest extends AllSetupTeardown
         $this->runTestCases('NORMSINV', $expectedResult, ...$args);
     }
 
-    public function providerNORMSINV(): array
+    public static function providerNORMSINV(): array
     {
         return require 'tests/data/Calculation/Statistical/NORMSINV.php';
     }
@@ -33,7 +33,7 @@ class NormSInvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerNormSInvArray(): array
+    public static function providerNormSInvArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PercentRankTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PercentRankTest.php
@@ -21,7 +21,7 @@ class PercentRankTest extends AllSetupTeardown
         }
     }
 
-    public function providerPERCENTRANK(): array
+    public static function providerPERCENTRANK(): array
     {
         return require 'tests/data/Calculation/Statistical/PERCENTRANK.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PercentileTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PercentileTest.php
@@ -14,7 +14,7 @@ class PercentileTest extends AllSetupTeardown
         $this->runTestCaseReference('PERCENTILE', $expectedResult, ...$args);
     }
 
-    public function providerPERCENTILE(): array
+    public static function providerPERCENTILE(): array
     {
         return require 'tests/data/Calculation/Statistical/PERCENTILE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutTest.php
@@ -16,7 +16,7 @@ class PermutTest extends AllSetupTeardown
         $this->runTestCases('PERMUT', $expectedResult, ...$args);
     }
 
-    public function providerPERMUT(): array
+    public static function providerPERMUT(): array
     {
         return require 'tests/data/Calculation/Statistical/PERMUT.php';
     }
@@ -33,7 +33,7 @@ class PermutTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerPermutArray(): array
+    public static function providerPermutArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutationATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PermutationATest.php
@@ -16,7 +16,7 @@ class PermutationATest extends AllSetupTeardown
         $this->runTestCases('PERMUTATIONA', $expectedResult, ...$args);
     }
 
-    public function providerPERMUT(): array
+    public static function providerPERMUT(): array
     {
         return require 'tests/data/Calculation/Statistical/PERMUTATIONA.php';
     }
@@ -33,7 +33,7 @@ class PermutationATest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerPermutationAArray(): array
+    public static function providerPermutationAArray(): array
     {
         return [
             'first argument row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PoissonTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/PoissonTest.php
@@ -16,7 +16,7 @@ class PoissonTest extends AllSetupTeardown
         $this->runTestCases('POISSON', $expectedResult, ...$args);
     }
 
-    public function providerPOISSON(): array
+    public static function providerPOISSON(): array
     {
         return require 'tests/data/Calculation/Statistical/POISSON.php';
     }
@@ -33,7 +33,7 @@ class PoissonTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerPoissonArray(): array
+    public static function providerPoissonArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/QuartileTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/QuartileTest.php
@@ -14,7 +14,7 @@ class QuartileTest extends AllSetupTeardown
         $this->runTestCaseReference('QUARTILE', $expectedResult, ...$args);
     }
 
-    public function providerQUARTILE(): array
+    public static function providerQUARTILE(): array
     {
         return require 'tests/data/Calculation/Statistical/QUARTILE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/RankTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/RankTest.php
@@ -21,7 +21,7 @@ class RankTest extends AllSetupTeardown
         }
     }
 
-    public function providerRANK(): array
+    public static function providerRANK(): array
     {
         return require 'tests/data/Calculation/Statistical/RANK.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/RsqTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/RsqTest.php
@@ -14,7 +14,7 @@ class RsqTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('RSQ', $expectedResult, ...$args);
     }
 
-    public function providerRSQ(): array
+    public static function providerRSQ(): array
     {
         return require 'tests/data/Calculation/Statistical/RSQ.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SkewTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SkewTest.php
@@ -14,7 +14,7 @@ class SkewTest extends AllSetupTeardown
         $this->runTestCaseReference('SKEW', $expectedResult, ...$args);
     }
 
-    public function providerSKEW(): array
+    public static function providerSKEW(): array
     {
         return require 'tests/data/Calculation/Statistical/SKEW.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SlopeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SlopeTest.php
@@ -14,7 +14,7 @@ class SlopeTest extends AllSetupTeardown
         $this->runTestCaseNoBracket('SLOPE', $expectedResult, ...$args);
     }
 
-    public function providerSLOPE(): array
+    public static function providerSLOPE(): array
     {
         return require 'tests/data/Calculation/Statistical/SLOPE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SmallTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SmallTest.php
@@ -16,7 +16,7 @@ class SmallTest extends AllSetupTeardown
         $this->runTestCaseReference('SMALL', $expectedResult, $values, $position);
     }
 
-    public function providerSMALL(): array
+    public static function providerSMALL(): array
     {
         return require 'tests/data/Calculation/Statistical/SMALL.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevATest.php
@@ -14,7 +14,7 @@ class StDevATest extends AllSetupTeardown
         $this->runTestCaseReference('STDEVA', $expectedResult, ...$args);
     }
 
-    public function providerSTDEVA(): array
+    public static function providerSTDEVA(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEVA.php';
     }
@@ -30,7 +30,7 @@ class StDevATest extends AllSetupTeardown
         $this->runTestCaseReference('STDEVA', $expectedResult, ...$args);
     }
 
-    public function providerOdsSTDEVA(): array
+    public static function providerOdsSTDEVA(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEVA_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevPATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevPATest.php
@@ -14,7 +14,7 @@ class StDevPATest extends AllSetupTeardown
         $this->runTestCaseReference('STDEVPA', $expectedResult, ...$args);
     }
 
-    public function providerSTDEVPA(): array
+    public static function providerSTDEVPA(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEVPA.php';
     }
@@ -30,7 +30,7 @@ class StDevPATest extends AllSetupTeardown
         $this->runTestCaseReference('STDEVPA', $expectedResult, ...$args);
     }
 
-    public function providerOdsSTDEVPA(): array
+    public static function providerOdsSTDEVPA(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEVPA_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevPTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevPTest.php
@@ -14,7 +14,7 @@ class StDevPTest extends AllSetupTeardown
         $this->runTestCaseReference('STDEVP', $expectedResult, ...$args);
     }
 
-    public function providerSTDEVP(): array
+    public static function providerSTDEVP(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEVP.php';
     }
@@ -30,7 +30,7 @@ class StDevPTest extends AllSetupTeardown
         $this->runTestCaseReference('STDEVP', $expectedResult, ...$args);
     }
 
-    public function providerOdsSTDEVP(): array
+    public static function providerOdsSTDEVP(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEVP_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StDevTest.php
@@ -14,7 +14,7 @@ class StDevTest extends AllSetupTeardown
         $this->runTestCaseReference('STDEV', $expectedResult, ...$args);
     }
 
-    public function providerSTDEV(): array
+    public static function providerSTDEV(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEV.php';
     }
@@ -30,7 +30,7 @@ class StDevTest extends AllSetupTeardown
         $this->runTestCaseReference('STDEV', $expectedResult, ...$args);
     }
 
-    public function providerOdsSTDEV(): array
+    public static function providerOdsSTDEV(): array
     {
         return require 'tests/data/Calculation/Statistical/STDEV_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StandardizeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/StandardizeTest.php
@@ -16,7 +16,7 @@ class StandardizeTest extends AllSetupTeardown
         $this->runTestCases('STANDARDIZE', $expectedResult, ...$args);
     }
 
-    public function providerSTANDARDIZE(): array
+    public static function providerSTANDARDIZE(): array
     {
         return require 'tests/data/Calculation/Statistical/STANDARDIZE.php';
     }
@@ -33,7 +33,7 @@ class StandardizeTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerStandardizeArray(): array
+    public static function providerStandardizeArray(): array
     {
         return [
             'row vector' => [[[-1.6666666666666667, -4.6666666666666667, -7.333333333333333, -10, -11.333333333333334]], '{12.5, 8, 4, 0, -2}', '15', '1.5'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SteyxTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/SteyxTest.php
@@ -16,7 +16,7 @@ class SteyxTest extends AllSetupTeardown
         $this->runTestCaseReference('STEYX', $expectedResult, $xargs, $yargs);
     }
 
-    public function providerSTEYX(): array
+    public static function providerSTEYX(): array
     {
         return require 'tests/data/Calculation/Statistical/STEYX.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TDistTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TDistTest.php
@@ -19,7 +19,7 @@ class TDistTest extends AllSetupTeardown
         $this->runTestCaseReference('TDIST', $expectedResult, $value, $degrees, $tails);
     }
 
-    public function providerTDIST(): array
+    public static function providerTDIST(): array
     {
         return require 'tests/data/Calculation/Statistical/TDIST.php';
     }
@@ -36,7 +36,7 @@ class TDistTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTDistArray(): array
+    public static function providerTDistArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TinvTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TinvTest.php
@@ -18,7 +18,7 @@ class TinvTest extends AllSetupTeardown
         $this->runTestCaseReference('TINV', $expectedResult, $probability, $degrees);
     }
 
-    public function providerTINV(): array
+    public static function providerTINV(): array
     {
         return require 'tests/data/Calculation/Statistical/TINV.php';
     }
@@ -35,7 +35,7 @@ class TinvTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTInvArray(): array
+    public static function providerTInvArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TrendTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TrendTest.php
@@ -26,7 +26,7 @@ class TrendTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result[0], 1E-12);
     }
 
-    public function providerGROWTH(): array
+    public static function providerGROWTH(): array
     {
         return require 'tests/data/Calculation/Statistical/TREND.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TrimMeanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/TrimMeanTest.php
@@ -15,7 +15,7 @@ class TrimMeanTest extends AllSetupTeardown
         $this->runTestCaseReference('TRIMMEAN', $expectedResult, $args, $percentage);
     }
 
-    public function providerTRIMMEAN(): array
+    public static function providerTRIMMEAN(): array
     {
         return require 'tests/data/Calculation/Statistical/TRIMMEAN.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarATest.php
@@ -14,7 +14,7 @@ class VarATest extends AllSetupTeardown
         $this->runTestCases('VARA', $expectedResult, ...$args);
     }
 
-    public function providerVARA(): array
+    public static function providerVARA(): array
     {
         return require 'tests/data/Calculation/Statistical/VARA.php';
     }
@@ -30,7 +30,7 @@ class VarATest extends AllSetupTeardown
         $this->runTestCases('VARA', $expectedResult, ...$args);
     }
 
-    public function providerOdsVARA(): array
+    public static function providerOdsVARA(): array
     {
         return require 'tests/data/Calculation/Statistical/VARA_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarPATest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarPATest.php
@@ -14,7 +14,7 @@ class VarPATest extends AllSetupTeardown
         $this->runTestCases('VARPA', $expectedResult, ...$args);
     }
 
-    public function providerVARPA(): array
+    public static function providerVARPA(): array
     {
         return require 'tests/data/Calculation/Statistical/VARPA.php';
     }
@@ -30,7 +30,7 @@ class VarPATest extends AllSetupTeardown
         $this->runTestCases('VARPA', $expectedResult, ...$args);
     }
 
-    public function providerOdsVARPA(): array
+    public static function providerOdsVARPA(): array
     {
         return require 'tests/data/Calculation/Statistical/VARPA_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarPTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarPTest.php
@@ -14,7 +14,7 @@ class VarPTest extends AllSetupTeardown
         $this->runTestCases('VARP', $expectedResult, ...$args);
     }
 
-    public function providerVARP(): array
+    public static function providerVARP(): array
     {
         return require 'tests/data/Calculation/Statistical/VARP.php';
     }
@@ -30,7 +30,7 @@ class VarPTest extends AllSetupTeardown
         $this->runTestCases('VARP', $expectedResult, ...$args);
     }
 
-    public function providerOdsVARP(): array
+    public static function providerOdsVARP(): array
     {
         return require 'tests/data/Calculation/Statistical/VARP_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/VarTest.php
@@ -14,7 +14,7 @@ class VarTest extends AllSetupTeardown
         $this->runTestCases('VAR', $expectedResult, ...$args);
     }
 
-    public function providerVAR(): array
+    public static function providerVAR(): array
     {
         return require 'tests/data/Calculation/Statistical/VAR.php';
     }
@@ -30,7 +30,7 @@ class VarTest extends AllSetupTeardown
         $this->runTestCases('VAR', $expectedResult, ...$args);
     }
 
-    public function providerOdsVAR(): array
+    public static function providerOdsVAR(): array
     {
         return require 'tests/data/Calculation/Statistical/VAR_ODS.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/WeibullTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/WeibullTest.php
@@ -16,7 +16,7 @@ class WeibullTest extends AllSetupTeardown
         $this->runTestCases('WEIBULL', $expectedResult, ...$args);
     }
 
-    public function providerWEIBULL(): array
+    public static function providerWEIBULL(): array
     {
         return require 'tests/data/Calculation/Statistical/WEIBULL.php';
     }
@@ -33,7 +33,7 @@ class WeibullTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerWeibullArray(): array
+    public static function providerWeibullArray(): array
     {
         return [
             'row/column vectors' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ZTestTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Statistical/ZTestTest.php
@@ -16,7 +16,7 @@ class ZTestTest extends AllSetupTeardown
         $this->runTestCaseReference('ZTEST', $expectedResult, ...$args);
     }
 
-    public function providerZTEST(): array
+    public static function providerZTEST(): array
     {
         return require 'tests/data/Calculation/Statistical/ZTEST.php';
     }
@@ -33,7 +33,7 @@ class ZTestTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerZTestArray(): array
+    public static function providerZTestArray(): array
     {
         return [
             'row vector' => [

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ArrayToTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ArrayToTextTest.php
@@ -17,7 +17,7 @@ class ArrayToTextTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerARRAYTOTEXT(): array
+    public static function providerARRAYTOTEXT(): array
     {
         return require 'tests/data/Calculation/TextData/ARRAYTOTEXT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharNonPrintableTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharNonPrintableTest.php
@@ -30,7 +30,7 @@ class CharNonPrintableTest extends AbstractFunctional
         $reloadedSpreadsheet->disconnectWorksheets();
     }
 
-    public function providerType(): array
+    public static function providerType(): array
     {
         return [
             ['Xlsx'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CharTest.php
@@ -26,7 +26,7 @@ class CharTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCHAR(): array
+    public static function providerCHAR(): array
     {
         return require 'tests/data/Calculation/TextData/CHAR.php';
     }
@@ -43,7 +43,7 @@ class CharTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCharArray(): array
+    public static function providerCharArray(): array
     {
         return [
             'row vector' => [[['P', 'H', 'P']], '{80, 72, 80}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CleanTest.php
@@ -26,7 +26,7 @@ class CleanTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCLEAN(): array
+    public static function providerCLEAN(): array
     {
         return require 'tests/data/Calculation/TextData/CLEAN.php';
     }
@@ -43,7 +43,7 @@ class CleanTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCleanArray(): array
+    public static function providerCleanArray(): array
     {
         return [
             'row vector' => [[['PHP', 'MS Excel', 'Open/Libre Office']], '{"PHP", "MS Excel", "Open/Libre Office"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/CodeTest.php
@@ -26,7 +26,7 @@ class CodeTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCODE(): array
+    public static function providerCODE(): array
     {
         return require 'tests/data/Calculation/TextData/CODE.php';
     }
@@ -43,7 +43,7 @@ class CodeTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerCodeArray(): array
+    public static function providerCodeArray(): array
     {
         return [
             'row vector' => [[[80, 72, 80]], '{"P", "H", "P"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ConcatenateTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ConcatenateTest.php
@@ -28,7 +28,7 @@ class ConcatenateTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCONCATENATE(): array
+    public static function providerCONCATENATE(): array
     {
         return require 'tests/data/Calculation/TextData/CONCATENATE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/DollarTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/DollarTest.php
@@ -31,7 +31,7 @@ class DollarTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDOLLAR(): array
+    public static function providerDOLLAR(): array
     {
         return require 'tests/data/Calculation/TextData/DOLLAR.php';
     }
@@ -48,7 +48,7 @@ class DollarTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerDollarArray(): array
+    public static function providerDollarArray(): array
     {
         return [
             'row vector #1' => [[['-$123.32', '$123.46', '$12,345.68']], '{-123.321, 123.456, 12345.6789}', '2'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ExactTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ExactTest.php
@@ -31,7 +31,7 @@ class ExactTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerEXACT(): array
+    public static function providerEXACT(): array
     {
         return require 'tests/data/Calculation/TextData/EXACT.php';
     }
@@ -48,7 +48,7 @@ class ExactTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerExactArray(): array
+    public static function providerExactArray(): array
     {
         return [
             'row vector #1' => [[[true, false, false]], '{"PHP", "php", "PHP8"}', '"PHP"'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FindTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FindTest.php
@@ -37,7 +37,7 @@ class FindTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerFIND(): array
+    public static function providerFIND(): array
     {
         return require 'tests/data/Calculation/TextData/FIND.php';
     }
@@ -54,7 +54,7 @@ class FindTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFindArray(): array
+    public static function providerFindArray(): array
     {
         return [
             'row vector #1' => [[[3, 4, '#VALUE!']], '"l"', '{"Hello", "World", "PhpSpreadsheet"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FixedTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/FixedTest.php
@@ -37,7 +37,7 @@ class FixedTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerFIXED(): array
+    public static function providerFIXED(): array
     {
         return require 'tests/data/Calculation/TextData/FIXED.php';
     }
@@ -54,7 +54,7 @@ class FixedTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerFixedArray(): array
+    public static function providerFixedArray(): array
     {
         return [
             'row vector #1' => [[['-123.32', '123.46', '12,345.68']], '{-123.321, 123.456, 12345.6789}', '2'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LeftTest.php
@@ -33,7 +33,7 @@ class LeftTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLEFT(): array
+    public static function providerLEFT(): array
     {
         return require 'tests/data/Calculation/TextData/LEFT.php';
     }
@@ -61,7 +61,7 @@ class LeftTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLocaleLEFT(): array
+    public static function providerLocaleLEFT(): array
     {
         return [
             ['VR', 'fr_FR', true, 2],
@@ -90,7 +90,7 @@ class LeftTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeLEFTTrue(): array
+    public static function providerCalculationTypeLEFTTrue(): array
     {
         return [
             'Excel LEFT(true, 1) AND LEFT("hello", true)' => [
@@ -126,7 +126,7 @@ class LeftTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeLEFTFalse(): array
+    public static function providerCalculationTypeLEFTFalse(): array
     {
         return [
             'Excel LEFT(false, 1) AND LEFT("hello", false)' => [
@@ -161,7 +161,7 @@ class LeftTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeLEFTNull(): array
+    public static function providerCalculationTypeLEFTNull(): array
     {
         return [
             'Excel LEFT(null, 1) AND LEFT("hello", null)' => [
@@ -194,7 +194,7 @@ class LeftTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLeftArray(): array
+    public static function providerLeftArray(): array
     {
         return [
             'row vector #1' => [[['Hel', 'Wor', 'Php']], '{"Hello", "World", "PhpSpreadsheet"}', '3'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LenTest.php
@@ -26,7 +26,7 @@ class LenTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLEN(): array
+    public static function providerLEN(): array
     {
         return require 'tests/data/Calculation/TextData/LEN.php';
     }
@@ -43,7 +43,7 @@ class LenTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLenArray(): array
+    public static function providerLenArray(): array
     {
         return [
             'row vector' => [[[3, 11, 14]], '{"PHP", "Hello World", "PhpSpreadsheet"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/LowerTest.php
@@ -27,7 +27,7 @@ class LowerTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLOWER(): array
+    public static function providerLOWER(): array
     {
         return require 'tests/data/Calculation/TextData/LOWER.php';
     }
@@ -52,7 +52,7 @@ class LowerTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLocaleLOWER(): array
+    public static function providerLocaleLOWER(): array
     {
         return [
             ['vrai', 'fr_FR', true],
@@ -78,7 +78,7 @@ class LowerTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerLowerArray(): array
+    public static function providerLowerArray(): array
     {
         return [
             'row vector' => [[["let's", 'all change', 'case']], '{"lEt\'S", "aLl chAngE", "cAsE"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/MidTest.php
@@ -39,7 +39,7 @@ class MidTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerMID(): array
+    public static function providerMID(): array
     {
         return require 'tests/data/Calculation/TextData/MID.php';
     }
@@ -69,7 +69,7 @@ class MidTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLocaleMID(): array
+    public static function providerLocaleMID(): array
     {
         return [
             ['RA', 'fr_FR', true, 2, 2],
@@ -100,7 +100,7 @@ class MidTest extends AllSetupTeardown
         self::assertEquals($resultB3, $sheet->getCell('B3')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeMIDTrue(): array
+    public static function providerCalculationTypeMIDTrue(): array
     {
         return [
             'Excel MID(true,3,1), MID("hello",true, 1), MID("hello", 2, true)' => [
@@ -140,7 +140,7 @@ class MidTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeMIDFalse(): array
+    public static function providerCalculationTypeMIDFalse(): array
     {
         return [
             'Excel MID(false,3,1), MID("hello", false, 1), MID("hello", 2, false)' => [
@@ -180,7 +180,7 @@ class MidTest extends AllSetupTeardown
         self::assertEquals($resultB3, $sheet->getCell('B3')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeMIDNull(): array
+    public static function providerCalculationTypeMIDNull(): array
     {
         return [
             'Excel MID(null,3,1), MID("hello", null, 1), MID("hello", 2, null)' => [
@@ -216,7 +216,7 @@ class MidTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerMidArray(): array
+    public static function providerMidArray(): array
     {
         return [
             'row vector #1' => [[['lo Wor', 'Spread']], '{"Hello World", "PhpSpreadsheet"}', '4', '6'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/NumberValueTest.php
@@ -39,7 +39,7 @@ class NumberValueTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, self::NV_PRECISION);
     }
 
-    public function providerNUMBERVALUE(): array
+    public static function providerNUMBERVALUE(): array
     {
         return require 'tests/data/Calculation/TextData/NUMBERVALUE.php';
     }
@@ -56,7 +56,7 @@ class NumberValueTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, self::NV_PRECISION);
     }
 
-    public function providerNumberValueArray(): array
+    public static function providerNumberValueArray(): array
     {
         return [
             'row vector #1' => [[[-123.321, 123.456, 12345.6789]], '{"-123,321", "123,456", "12 345,6789"}', '","', '" "'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/OpenOfficeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/OpenOfficeTest.php
@@ -19,7 +19,7 @@ class OpenOfficeTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerOpenOffice(): array
+    public static function providerOpenOffice(): array
     {
         return require 'tests/data/Calculation/TextData/OpenOffice.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ProperTest.php
@@ -27,7 +27,7 @@ class ProperTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerPROPER(): array
+    public static function providerPROPER(): array
     {
         return require 'tests/data/Calculation/TextData/PROPER.php';
     }
@@ -52,7 +52,7 @@ class ProperTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLocaleLOWER(): array
+    public static function providerLocaleLOWER(): array
     {
         return [
             ['Vrai', 'fr_FR', true],
@@ -78,7 +78,7 @@ class ProperTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerProperArray(): array
+    public static function providerProperArray(): array
     {
         return [
             'row vector' => [[["Let's", 'All Change', 'Case']], '{"lEt\'S", "aLl chAngE", "cAsE"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReplaceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReplaceTest.php
@@ -44,7 +44,7 @@ class ReplaceTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerREPLACE(): array
+    public static function providerREPLACE(): array
     {
         return require 'tests/data/Calculation/TextData/REPLACE.php';
     }
@@ -66,7 +66,7 @@ class ReplaceTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerReplaceArray(): array
+    public static function providerReplaceArray(): array
     {
         return [
             'row vector' => [[['Elephpant', 'ElePHPant']], '"Elephant"', '4', '2', '{"php", "PHP"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReptTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ReptTest.php
@@ -31,7 +31,7 @@ class ReptTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerREPT(): array
+    public static function providerREPT(): array
     {
         return require 'tests/data/Calculation/TextData/REPT.php';
     }
@@ -48,7 +48,7 @@ class ReptTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerReptArray(): array
+    public static function providerReptArray(): array
     {
         return [
             'row vector #1' => [[['PHPPHPPHP', 'HAHAHA', 'HOHOHO']], '{"PHP", "HA", "HO"}', '3'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/RightTest.php
@@ -33,7 +33,7 @@ class RightTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerRIGHT(): array
+    public static function providerRIGHT(): array
     {
         return require 'tests/data/Calculation/TextData/RIGHT.php';
     }
@@ -61,7 +61,7 @@ class RightTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLocaleRIGHT(): array
+    public static function providerLocaleRIGHT(): array
     {
         return [
             ['RAI', 'fr_FR', true, 3],
@@ -90,7 +90,7 @@ class RightTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeRIGHTTrue(): array
+    public static function providerCalculationTypeRIGHTTrue(): array
     {
         return [
             'Excel RIGHT(true, 1) AND RIGHT("hello", true)' => [
@@ -126,7 +126,7 @@ class RightTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeRIGHTFalse(): array
+    public static function providerCalculationTypeRIGHTFalse(): array
     {
         return [
             'Excel RIGHT(false, 1) AND RIGHT("hello", false)' => [
@@ -161,7 +161,7 @@ class RightTest extends AllSetupTeardown
         self::assertEquals($resultB2, $sheet->getCell('B2')->getCalculatedValue());
     }
 
-    public function providerCalculationTypeRIGHTNull(): array
+    public static function providerCalculationTypeRIGHTNull(): array
     {
         return [
             'Excel RIGHT(null, 1) AND RIGHT("hello", null)' => [
@@ -194,7 +194,7 @@ class RightTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerRightArray(): array
+    public static function providerRightArray(): array
     {
         return [
             'row vector #1' => [[['llo', 'rld', 'eet']], '{"Hello", "World", "PhpSpreadsheet"}', '3'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SearchTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SearchTest.php
@@ -37,7 +37,7 @@ class SearchTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerSEARCH(): array
+    public static function providerSEARCH(): array
     {
         return require 'tests/data/Calculation/TextData/SEARCH.php';
     }
@@ -54,7 +54,7 @@ class SearchTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSearchArray(): array
+    public static function providerSearchArray(): array
     {
         return [
             'row vector #1' => [[[3, 4, '#VALUE!']], '"L"', '{"Hello", "World", "PhpSpreadsheet"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SubstituteTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/SubstituteTest.php
@@ -44,7 +44,7 @@ class SubstituteTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerSUBSTITUTE(): array
+    public static function providerSUBSTITUTE(): array
     {
         return require 'tests/data/Calculation/TextData/SUBSTITUTE.php';
     }
@@ -61,7 +61,7 @@ class SubstituteTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerSubstituteArray(): array
+    public static function providerSubstituteArray(): array
     {
         return [
             'row vector' => [[['ElePHPant', 'EleFFant']], '"Elephant"', '"ph"', '{"PHP", "FF"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TTest.php
@@ -25,7 +25,7 @@ class TTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerT(): array
+    public static function providerT(): array
     {
         return require 'tests/data/Calculation/TextData/T.php';
     }
@@ -42,7 +42,7 @@ class TTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerTArray(): array
+    public static function providerTArray(): array
     {
         return [
             'row vector #1' => [[['PHP', '', 'PHP8']], '{"PHP", 99, "PHP8"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextAfterTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextAfterTest.php
@@ -29,7 +29,7 @@ class TextAfterTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerTEXTAFTER(): array
+    public static function providerTEXTAFTER(): array
     {
         return require 'tests/data/Calculation/TextData/TEXTAFTER.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextBeforeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextBeforeTest.php
@@ -29,7 +29,7 @@ class TextBeforeTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerTEXTBEFORE(): array
+    public static function providerTEXTBEFORE(): array
     {
         return require 'tests/data/Calculation/TextData/TEXTBEFORE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextJoinTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextJoinTest.php
@@ -30,7 +30,7 @@ class TextJoinTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerTEXTJOIN(): array
+    public static function providerTEXTJOIN(): array
     {
         return require 'tests/data/Calculation/TextData/TEXTJOIN.php';
     }
@@ -47,7 +47,7 @@ class TextJoinTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTextjoinArray(): array
+    public static function providerTextjoinArray(): array
     {
         return [
             'row vector #1' => [[['AB,CD,EF', 'AB;CD;EF']], '{",", ";"}', 'FALSE', '"AB", "CD", "EF"'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextSplitTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextSplitTest.php
@@ -55,7 +55,7 @@ class TextSplitTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerTEXTSPLIT(): array
+    public static function providerTEXTSPLIT(): array
     {
         return require 'tests/data/Calculation/TextData/TEXTSPLIT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TextTest.php
@@ -31,7 +31,7 @@ class TextTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerTEXT(): array
+    public static function providerTEXT(): array
     {
         return require 'tests/data/Calculation/TextData/TEXT.php';
     }
@@ -48,7 +48,7 @@ class TextTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTextArray(): array
+    public static function providerTextArray(): array
     {
         return [
             'row vector' => [[['123.75%', '1 19/80']], '1.2375', '{"0.00%", "0 ??/???"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/TrimTest.php
@@ -26,7 +26,7 @@ class TrimTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerTRIM(): array
+    public static function providerTRIM(): array
     {
         return require 'tests/data/Calculation/TextData/TRIM.php';
     }
@@ -43,7 +43,7 @@ class TrimTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerTrimArray(): array
+    public static function providerTrimArray(): array
     {
         return [
             'row vector' => [[['PHP', 'MS Excel', 'Open/Libre Office']], '{"  PHP ", " MS   Excel ", " Open/Libre   Office "}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/UpperTest.php
@@ -27,7 +27,7 @@ class UpperTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerUPPER(): array
+    public static function providerUPPER(): array
     {
         return require 'tests/data/Calculation/TextData/UPPER.php';
     }
@@ -52,7 +52,7 @@ class UpperTest extends AllSetupTeardown
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerLocaleLOWER(): array
+    public static function providerLocaleLOWER(): array
     {
         return [
             ['VRAI', 'fr_FR', true],
@@ -78,7 +78,7 @@ class UpperTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerUpperArray(): array
+    public static function providerUpperArray(): array
     {
         return [
             'row vector' => [[["LET'S", 'ALL CHANGE', 'CASE']], '{"lEt\'S", "aLl chAngE", "cAsE"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueTest.php
@@ -62,7 +62,7 @@ class ValueTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1E-8);
     }
 
-    public function providerVALUE(): array
+    public static function providerVALUE(): array
     {
         return require 'tests/data/Calculation/TextData/VALUE.php';
     }
@@ -79,7 +79,7 @@ class ValueTest extends AllSetupTeardown
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-14);
     }
 
-    public function providerValueArray(): array
+    public static function providerValueArray(): array
     {
         return [
             'row vector' => [[[44604, -1234.567]], '{"12-Feb-2022", "$ -1,234.567"}'],

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueToTextTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/TextData/ValueToTextTest.php
@@ -24,7 +24,7 @@ class ValueToTextTest extends AllSetupTeardown
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerVALUE(): array
+    public static function providerVALUE(): array
     {
         return require 'tests/data/Calculation/TextData/VALUETOTEXT.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Web/UrlEncodeTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Web/UrlEncodeTest.php
@@ -19,7 +19,7 @@ class UrlEncodeTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerURLENCODE(): array
+    public static function providerURLENCODE(): array
     {
         return require 'tests/data/Calculation/Web/URLENCODE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/Functions/Web/WebServiceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/Functions/Web/WebServiceTest.php
@@ -56,7 +56,7 @@ class WebServiceTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerWEBSERVICE(): array
+    public static function providerWEBSERVICE(): array
     {
         return require 'tests/data/Calculation/Web/WEBSERVICE.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/FunctionsTest.php
@@ -83,7 +83,7 @@ class FunctionsTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIfCondition(): array
+    public static function providerIfCondition(): array
     {
         return require 'tests/data/Calculation/Functions/IF_CONDITION.php';
     }

--- a/tests/PhpSpreadsheetTests/Calculation/MergedCellTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/MergedCellTest.php
@@ -39,7 +39,7 @@ class MergedCellTest extends TestCase
         $spreadSheet->disconnectWorksheets();
     }
 
-    public function providerWorksheetFormulaeColumns(): array
+    public static function providerWorksheetFormulaeColumns(): array
     {
         return [
             ['=SUM(A1:A5)', 6.6],
@@ -81,7 +81,7 @@ class MergedCellTest extends TestCase
         $spreadSheet->disconnectWorksheets();
     }
 
-    public function providerWorksheetFormulaeRows(): array
+    public static function providerWorksheetFormulaeRows(): array
     {
         return [
             ['=SUM(A1:E1)', 6.6],

--- a/tests/PhpSpreadsheetTests/Calculation/ParseFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/ParseFormulaTest.php
@@ -24,7 +24,7 @@ class ParseFormulaTest extends TestCase
         self::assertEquals($expectedStack, $stack);
     }
 
-    public function providerBinaryOperations(): array
+    public static function providerBinaryOperations(): array
     {
         return [
             'Unary negative with Value' => [

--- a/tests/PhpSpreadsheetTests/Calculation/RefErrorTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/RefErrorTest.php
@@ -35,7 +35,7 @@ class RefErrorTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerRefError(): array
+    public static function providerRefError(): array
     {
         return [
             'Subtotal9 Ok' => [12, '=SUBTOTAL(A1,A2:A4)'],

--- a/tests/PhpSpreadsheetTests/Calculation/RowColumnReferenceTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/RowColumnReferenceTest.php
@@ -49,7 +49,7 @@ class RowColumnReferenceTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1.0e-12);
     }
 
-    public function providerCurrentWorksheetFormulae(): array
+    public static function providerCurrentWorksheetFormulae(): array
     {
         return [
             'relative range in active worksheet' => ['=SUM(B1:B3)', 15.4],

--- a/tests/PhpSpreadsheetTests/Calculation/StructuredReferenceFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/StructuredReferenceFormulaTest.php
@@ -61,7 +61,7 @@ class StructuredReferenceFormulaTest extends TestCase
         self::assertSame(ExcelError::REF(), $result);
     }
 
-    public function structuredReferenceProvider(): array
+    public static function structuredReferenceProvider(): array
     {
         return [
             [26.0, 'E2'],

--- a/tests/PhpSpreadsheetTests/Calculation/TranslationTest.php
+++ b/tests/PhpSpreadsheetTests/Calculation/TranslationTest.php
@@ -55,7 +55,7 @@ class TranslationTest extends TestCase
         self::assertSame($formula, $restoredFormula);
     }
 
-    public function providerTranslations(): array
+    public static function providerTranslations(): array
     {
         return require 'tests/data/Calculation/Translations.php';
     }

--- a/tests/PhpSpreadsheetTests/Cell/AddressHelperTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AddressHelperTest.php
@@ -18,7 +18,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerR1C1ConversionToA1Absolute(): array
+    public static function providerR1C1ConversionToA1Absolute(): array
     {
         return require 'tests/data/Cell/R1C1ConversionToA1Absolute.php';
     }
@@ -47,7 +47,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerR1C1ConversionToA1Relative(): array
+    public static function providerR1C1ConversionToA1Relative(): array
     {
         return require 'tests/data/Cell/R1C1ConversionToA1Relative.php';
     }
@@ -62,7 +62,7 @@ class AddressHelperTest extends TestCase
         AddressHelper::convertToA1($address);
     }
 
-    public function providerR1C1ConversionToA1Exception(): array
+    public static function providerR1C1ConversionToA1Exception(): array
     {
         return require 'tests/data/Cell/R1C1ConversionToA1Exception.php';
     }
@@ -77,7 +77,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerA1ConversionToR1C1Absolute(): array
+    public static function providerA1ConversionToR1C1Absolute(): array
     {
         return require 'tests/data/Cell/A1ConversionToR1C1Absolute.php';
     }
@@ -92,7 +92,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerA1ConversionToR1C1Relative(): array
+    public static function providerA1ConversionToR1C1Relative(): array
     {
         return require 'tests/data/Cell/A1ConversionToR1C1Relative.php';
     }
@@ -107,7 +107,7 @@ class AddressHelperTest extends TestCase
         AddressHelper::convertToR1C1($address);
     }
 
-    public function providerA1ConversionToR1C1Exception(): array
+    public static function providerA1ConversionToR1C1Exception(): array
     {
         return require 'tests/data/Cell/A1ConversionToR1C1Exception.php';
     }
@@ -122,7 +122,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerConvertFormulaToA1FromSpreadsheetXml(): array
+    public static function providerConvertFormulaToA1FromSpreadsheetXml(): array
     {
         return require 'tests/data/Cell/ConvertFormulaToA1FromSpreadsheetXml.php';
     }
@@ -137,7 +137,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerConvertFormulaToA1FromR1C1Absolute(): array
+    public static function providerConvertFormulaToA1FromR1C1Absolute(): array
     {
         return require 'tests/data/Cell/ConvertFormulaToA1FromR1C1Absolute.php';
     }
@@ -152,7 +152,7 @@ class AddressHelperTest extends TestCase
         self::assertSame($expectedValue, $actualValue);
     }
 
-    public function providerConvertFormulaToA1FromR1C1Relative(): array
+    public static function providerConvertFormulaToA1FromR1C1Relative(): array
     {
         return require 'tests/data/Cell/ConvertFormulaToA1FromR1C1Relative.php';
     }

--- a/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/AdvancedValueBinderTest.php
@@ -122,7 +122,7 @@ class AdvancedValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function currencyProvider(): array
+    public static function currencyProvider(): array
     {
         return [
             ['$10.11', 10.11, ',', '.', '$'],
@@ -156,7 +156,7 @@ class AdvancedValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function fractionProvider(): array
+    public static function fractionProvider(): array
     {
         return [
             ['1/5', 0.2],
@@ -192,7 +192,7 @@ class AdvancedValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function percentageProvider(): array
+    public static function percentageProvider(): array
     {
         return [
             ['10%', 0.1],
@@ -222,7 +222,7 @@ class AdvancedValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function timeProvider(): array
+    public static function timeProvider(): array
     {
         return [
             ['1:20', 0.05555555556],
@@ -247,7 +247,7 @@ class AdvancedValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function stringProvider(): array
+    public static function stringProvider(): array
     {
         return [
             ['Hello World', false],

--- a/tests/PhpSpreadsheetTests/Cell/CellAddressTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellAddressTest.php
@@ -27,7 +27,7 @@ class CellAddressTest extends TestCase
         self::assertSame($expectedColumnName, $cellAddressObject->columnName());
     }
 
-    public function providerCreateFromCellAddress(): array
+    public static function providerCreateFromCellAddress(): array
     {
         return [
             ['A1', 'A', 1, 1],
@@ -53,7 +53,7 @@ class CellAddressTest extends TestCase
         CellAddress::fromCellAddress($cellAddress);
     }
 
-    public function providerCreateFromCellAddressException(): array
+    public static function providerCreateFromCellAddressException(): array
     {
         return [
             ['INVALID'],
@@ -96,7 +96,7 @@ class CellAddressTest extends TestCase
         CellAddress::fromColumnAndRow($columnId, $rowId);
     }
 
-    public function providerCreateFromColumnAndRow(): array
+    public static function providerCreateFromColumnAndRow(): array
     {
         return [
             [1, 1, 'A1', 'A'],
@@ -124,7 +124,7 @@ class CellAddressTest extends TestCase
         self::assertSame($expectedColumnName, $cellAddressObject->columnName());
     }
 
-    public function providerCreateFromColumnRowArray(): array
+    public static function providerCreateFromColumnRowArray(): array
     {
         return [
             [1, 1, 'A1', 'A'],
@@ -148,7 +148,7 @@ class CellAddressTest extends TestCase
         CellAddress::fromColumnRowArray($columnRowArray);
     }
 
-    public function providerCreateFromColumnRowException(): array
+    public static function providerCreateFromColumnRowException(): array
     {
         return [
             [-1, 1],
@@ -179,7 +179,7 @@ class CellAddressTest extends TestCase
         self::assertSame($expectedColumnName, $cellAddressObject->columnName());
     }
 
-    public function providerCreateFromCellAddressWithWorksheet(): array
+    public static function providerCreateFromCellAddressWithWorksheet(): array
     {
         return [
             ['A1', "'Mark''s Worksheet'!A1", 'A', 1, 1],

--- a/tests/PhpSpreadsheetTests/Cell/CellDetachTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellDetachTest.php
@@ -37,7 +37,7 @@ class CellDetachTest extends TestCase
         }
     }
 
-    public function providerMethodName(): array
+    public static function providerMethodName(): array
     {
         return [
             ['updateInCollection'],
@@ -67,7 +67,7 @@ class CellDetachTest extends TestCase
         }
     }
 
-    public function providerMethodNameSet(): array
+    public static function providerMethodNameSet(): array
     {
         return [
             ['setDataValidation'],

--- a/tests/PhpSpreadsheetTests/Cell/CellTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CellTest.php
@@ -86,7 +86,7 @@ class CellTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerSetValueExplicit(): array
+    public static function providerSetValueExplicit(): array
     {
         return require 'tests/data/Cell/SetValueExplicit.php';
     }
@@ -118,7 +118,7 @@ class CellTest extends TestCase
         $cell->setValueExplicit($value, $dataType);
     }
 
-    public function providerSetValueExplicitException(): array
+    public static function providerSetValueExplicitException(): array
     {
         return require 'tests/data/Cell/SetValueExplicitException.php';
     }

--- a/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/CoordinateTest.php
@@ -24,7 +24,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($stringBack, $string, 'should be able to get the original input with opposite method');
     }
 
-    public function providerColumnString(): array
+    public static function providerColumnString(): array
     {
         return require 'tests/data/ColumnString.php';
     }
@@ -74,7 +74,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($columnIndexBack, $columnIndex, 'should be able to get the original input with opposite method');
     }
 
-    public function providerColumnIndex(): array
+    public static function providerColumnIndex(): array
     {
         return require 'tests/data/ColumnIndex.php';
     }
@@ -91,7 +91,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCoordinates(): array
+    public static function providerCoordinates(): array
     {
         return require 'tests/data/CellCoordinates.php';
     }
@@ -105,7 +105,7 @@ class CoordinateTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerIndexesFromString(): array
+    public static function providerIndexesFromString(): array
     {
         return require 'tests/data/Cell/IndexesFromString.php';
     }
@@ -167,7 +167,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerAbsoluteCoordinates(): array
+    public static function providerAbsoluteCoordinates(): array
     {
         return require 'tests/data/CellAbsoluteCoordinate.php';
     }
@@ -199,7 +199,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerAbsoluteReferences(): array
+    public static function providerAbsoluteReferences(): array
     {
         return require 'tests/data/CellAbsoluteReference.php';
     }
@@ -237,7 +237,7 @@ class CoordinateTest extends TestCase
         }
     }
 
-    public function providerSplitRange(): array
+    public static function providerSplitRange(): array
     {
         return require 'tests/data/CellSplitRange.php';
     }
@@ -254,7 +254,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerBuildRange(): array
+    public static function providerBuildRange(): array
     {
         return require 'tests/data/CellBuildRange.php';
     }
@@ -289,7 +289,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerRangeBoundaries(): array
+    public static function providerRangeBoundaries(): array
     {
         return require 'tests/data/CellRangeBoundaries.php';
     }
@@ -306,7 +306,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerRangeDimension(): array
+    public static function providerRangeDimension(): array
     {
         return require 'tests/data/CellRangeDimension.php';
     }
@@ -323,7 +323,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerGetRangeBoundaries(): array
+    public static function providerGetRangeBoundaries(): array
     {
         return require 'tests/data/CellGetRangeBoundaries.php';
     }
@@ -340,7 +340,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerExtractAllCellReferencesInRange(): array
+    public static function providerExtractAllCellReferencesInRange(): array
     {
         return require 'tests/data/CellExtractAllCellReferencesInRange.php';
     }
@@ -358,7 +358,7 @@ class CoordinateTest extends TestCase
         Coordinate::extractAllCellReferencesInRange($range);
     }
 
-    public function providerInvalidRange(): array
+    public static function providerInvalidRange(): array
     {
         return [['Z1:A1'], ['A4:A1'], ['B1:A1'], ['AA1:Z1']];
     }
@@ -375,7 +375,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerMergeRangesInCollection(): array
+    public static function providerMergeRangesInCollection(): array
     {
         return require 'tests/data/CellMergeRangesInCollection.php';
     }
@@ -392,7 +392,7 @@ class CoordinateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerCoordinateIsRange(): array
+    public static function providerCoordinateIsRange(): array
     {
         return require 'tests/data/CoordinateIsRange.php';
     }

--- a/tests/PhpSpreadsheetTests/Cell/DefaultValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/DefaultValueBinderTest.php
@@ -28,7 +28,7 @@ class DefaultValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function binderProvider(): array
+    public static function binderProvider(): array
     {
         return [
             [null],
@@ -60,7 +60,7 @@ class DefaultValueBinderTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDataTypeForValue(): array
+    public static function providerDataTypeForValue(): array
     {
         return require 'tests/data/Cell/DefaultValueBinder.php';
     }

--- a/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
+++ b/tests/PhpSpreadsheetTests/Cell/StringValueBinderTest.php
@@ -50,7 +50,7 @@ class StringValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDataValuesDefault(): array
+    public static function providerDataValuesDefault(): array
     {
         return [
             [null, '', DataType::TYPE_STRING],
@@ -101,7 +101,7 @@ class StringValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDataValuesSuppressNullConversion(): array
+    public static function providerDataValuesSuppressNullConversion(): array
     {
         return [
             [null, null, DataType::TYPE_NULL],
@@ -133,7 +133,7 @@ class StringValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDataValuesSuppressBooleanConversion(): array
+    public static function providerDataValuesSuppressBooleanConversion(): array
     {
         return [
             [true, true, DataType::TYPE_BOOL],
@@ -166,7 +166,7 @@ class StringValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDataValuesSuppressNumericConversion(): array
+    public static function providerDataValuesSuppressNumericConversion(): array
     {
         return [
             [123, 123, DataType::TYPE_NUMERIC],
@@ -206,7 +206,7 @@ class StringValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDataValuesSuppressFormulaConversion(): array
+    public static function providerDataValuesSuppressFormulaConversion(): array
     {
         return [
             ['=SUM(A1:C3)', '=SUM(A1:C3)', DataType::TYPE_FORMULA, false],
@@ -236,7 +236,7 @@ class StringValueBinderTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerDataValuesSuppressAllConversion(): array
+    public static function providerDataValuesSuppressAllConversion(): array
     {
         return [
             [null, null, DataType::TYPE_NULL],

--- a/tests/PhpSpreadsheetTests/CellReferenceHelperTest.php
+++ b/tests/PhpSpreadsheetTests/CellReferenceHelperTest.php
@@ -18,7 +18,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperInsertColumnsProvider(): array
+    public static function cellReferenceHelperInsertColumnsProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -72,7 +72,7 @@ class CellReferenceHelperTest extends TestCase
         $cellReferenceHelper->updateCellReference('A1:A6');
     }
 
-    public function cellReferenceHelperDeleteColumnsProvider(): array
+    public static function cellReferenceHelperDeleteColumnsProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -100,7 +100,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperInsertRowsProvider(): array
+    public static function cellReferenceHelperInsertRowsProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -132,7 +132,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperDeleteRowsProvider(): array
+    public static function cellReferenceHelperDeleteRowsProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -160,7 +160,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperInsertColumnsAbsoluteProvider(): array
+    public static function cellReferenceHelperInsertColumnsAbsoluteProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -188,7 +188,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperDeleteColumnsAbsoluteProvider(): array
+    public static function cellReferenceHelperDeleteColumnsAbsoluteProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -216,7 +216,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperInsertRowsAbsoluteProvider(): array
+    public static function cellReferenceHelperInsertRowsAbsoluteProvider(): array
     {
         return [
             ['A1', 'A1'],
@@ -244,7 +244,7 @@ class CellReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function cellReferenceHelperDeleteRowsAbsoluteProvider(): array
+    public static function cellReferenceHelperDeleteRowsAbsoluteProvider(): array
     {
         return [
             ['A1', 'A1'],

--- a/tests/PhpSpreadsheetTests/Chart/Charts32CatAxValAxTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/Charts32CatAxValAxTest.php
@@ -162,7 +162,7 @@ class Charts32CatAxValAxTest extends TestCase
         }
     }
 
-    public function providerCatAxValAx(): array
+    public static function providerCatAxValAx(): array
     {
         return [
             [true],

--- a/tests/PhpSpreadsheetTests/Chart/Charts32XmlTest.php
+++ b/tests/PhpSpreadsheetTests/Chart/Charts32XmlTest.php
@@ -38,7 +38,7 @@ class Charts32XmlTest extends TestCase
         self::assertSame($expectedCount, substr_count($data, '<c:smooth val="1"/>'));
     }
 
-    public function providerScatterCharts(): array
+    public static function providerScatterCharts(): array
     {
         return [
             'no line' => [0, '32readwriteScatterChart1.xlsx'],
@@ -114,7 +114,7 @@ class Charts32XmlTest extends TestCase
         }
     }
 
-    public function providerCatAxValAx(): array
+    public static function providerCatAxValAx(): array
     {
         return [
             [true],

--- a/tests/PhpSpreadsheetTests/DefinedNameFormulaTest.php
+++ b/tests/PhpSpreadsheetTests/DefinedNameFormulaTest.php
@@ -142,7 +142,7 @@ class DefinedNameFormulaTest extends TestCase
         self::assertSame($globalFormulaValue, $localScopedFormula->getValue());
     }
 
-    public function providerRangeOrFormula(): array
+    public static function providerRangeOrFormula(): array
     {
         return [
             'simple range' => ['A1', false],

--- a/tests/PhpSpreadsheetTests/Document/EpochTest.php
+++ b/tests/PhpSpreadsheetTests/Document/EpochTest.php
@@ -8,7 +8,7 @@ use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class EpochTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Ods', '1921-03-17 11:30:00Z'],
@@ -66,7 +66,7 @@ class EpochTest extends AbstractFunctional
         }
     }
 
-    public function providerFormats2(): array
+    public static function providerFormats2(): array
     {
         return [
             ['Ods'],

--- a/tests/PhpSpreadsheetTests/Document/PropertiesTest.php
+++ b/tests/PhpSpreadsheetTests/Document/PropertiesTest.php
@@ -60,7 +60,7 @@ class PropertiesTest extends TestCase
         self::assertEquals($expectedCreationTime, $this->properties->getCreated());
     }
 
-    public function providerCreationTime(): array
+    public static function providerCreationTime(): array
     {
         return [
             [null, null],
@@ -92,7 +92,7 @@ class PropertiesTest extends TestCase
         self::assertEquals($expectedModifiedTime, $this->properties->getModified());
     }
 
-    public function providerModifiedTime(): array
+    public static function providerModifiedTime(): array
     {
         return [
             [null, null],
@@ -183,7 +183,7 @@ class PropertiesTest extends TestCase
         self::assertSame($expectedValue, $result);
     }
 
-    public function providerCustomProperties(): array
+    public static function providerCustomProperties(): array
     {
         return [
             [Properties::PROPERTY_TYPE_STRING, null, 'Editor', null],

--- a/tests/PhpSpreadsheetTests/Document/SecurityTest.php
+++ b/tests/PhpSpreadsheetTests/Document/SecurityTest.php
@@ -38,7 +38,7 @@ class SecurityTest extends AbstractFunctional
         self::assertSame($hashedRevisionsPassword, $reloadedSecurity->getWorkbookPassword());
     }
 
-    public function providerLocks(): array
+    public static function providerLocks(): array
     {
         return [
             [false, false, false],

--- a/tests/PhpSpreadsheetTests/DocumentGeneratorTest.php
+++ b/tests/PhpSpreadsheetTests/DocumentGeneratorTest.php
@@ -27,7 +27,7 @@ class DocumentGeneratorTest extends TestCase
         self::assertEquals($expected, DocumentGenerator::generateFunctionListByCategory($phpSpreadsheetFunctions));
     }
 
-    public function providerGenerateFunctionListByName(): array
+    public static function providerGenerateFunctionListByName(): array
     {
         return [
             [
@@ -58,7 +58,7 @@ class DocumentGeneratorTest extends TestCase
         ];
     }
 
-    public function providerGenerateFunctionListByCategory(): array
+    public static function providerGenerateFunctionListByCategory(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Functional/ActiveSheetTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ActiveSheetTest.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Protection;
 
 class ActiveSheetTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xls'],

--- a/tests/PhpSpreadsheetTests/Functional/ColumnWidthTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ColumnWidthTest.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\ColumnDimension;
 
 class ColumnWidthTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xlsx'],

--- a/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/CommentsTest.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Style\Alignment;
 
 class CommentsTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Html'],

--- a/tests/PhpSpreadsheetTests/Functional/ConditionalStopIfTrueTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ConditionalStopIfTrueTest.php
@@ -9,7 +9,7 @@ class ConditionalStopIfTrueTest extends AbstractFunctional
     const COLOR_GREEN = 'FF99FF66';
     const COLOR_RED = 'FFFF5050';
 
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xlsx'],

--- a/tests/PhpSpreadsheetTests/Functional/EnclosureTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/EnclosureTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class EnclosureTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Html'],

--- a/tests/PhpSpreadsheetTests/Functional/FreezePaneTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/FreezePaneTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class FreezePaneTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xls'],

--- a/tests/PhpSpreadsheetTests/Functional/MergedCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/MergedCellsTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class MergedCellsTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Html'],

--- a/tests/PhpSpreadsheetTests/Functional/PrintAreaTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/PrintAreaTest.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class PrintAreaTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xls'],

--- a/tests/PhpSpreadsheetTests/Functional/ReadBlankCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ReadBlankCellsTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class ReadBlankCellsTest extends AbstractFunctional
 {
-    public function providerSheetFormat(): array
+    public static function providerSheetFormat(): array
     {
         return [
             ['Xlsx'],

--- a/tests/PhpSpreadsheetTests/Functional/ReadFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/ReadFilterTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class ReadFilterTest extends AbstractFunctional
 {
-    public function providerCellsValues(): array
+    public static function providerCellsValues(): array
     {
         $cellValues = [
             // one argument as a multidimensional array

--- a/tests/PhpSpreadsheetTests/Functional/SelectedCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/SelectedCellsTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class SelectedCellsTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xls'],

--- a/tests/PhpSpreadsheetTests/Functional/StreamTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/StreamTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class StreamTest extends TestCase
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         $providerFormats = [
             ['Xls'],

--- a/tests/PhpSpreadsheetTests/Functional/TypeAttributePreservationTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/TypeAttributePreservationTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class TypeAttributePreservationTest extends AbstractFunctional
 {
-    public function providerFormulae(): array
+    public static function providerFormulae(): array
     {
         $formats = ['Xlsx'];
         $data = require 'tests/data/Functional/TypeAttributePreservation/Formula.php';

--- a/tests/PhpSpreadsheetTests/Functional/WorkbookViewAttributesTest.php
+++ b/tests/PhpSpreadsheetTests/Functional/WorkbookViewAttributesTest.php
@@ -6,7 +6,7 @@ use PhpOffice\PhpSpreadsheet\Spreadsheet;
 
 class WorkbookViewAttributesTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xlsx'],

--- a/tests/PhpSpreadsheetTests/Helper/DimensionTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/DimensionTest.php
@@ -33,7 +33,7 @@ class DimensionTest extends TestCase
         (new Dimension('999'))->toUnit('pikachu');
     }
 
-    public function providerCellWidth(): array
+    public static function providerCellWidth(): array
     {
         return [
             [12.0, '12'],
@@ -52,7 +52,7 @@ class DimensionTest extends TestCase
         ];
     }
 
-    public function providerConvertUoM(): array
+    public static function providerConvertUoM(): array
     {
         return [
             [60, '8.54', Dimension::UOM_PIXELS],

--- a/tests/PhpSpreadsheetTests/Helper/HtmlTest.php
+++ b/tests/PhpSpreadsheetTests/Helper/HtmlTest.php
@@ -21,7 +21,7 @@ class HtmlTest extends TestCase
         self::assertSame($expected, $actual->getPlainText());
     }
 
-    public function providerUtf8EncodingSupport(): array
+    public static function providerUtf8EncodingSupport(): array
     {
         return [
             ['foo', 'foo'],

--- a/tests/PhpSpreadsheetTests/IOFactoryTest.php
+++ b/tests/PhpSpreadsheetTests/IOFactoryTest.php
@@ -24,7 +24,7 @@ class IOFactoryTest extends TestCase
         self::assertSame($expected, get_class($actual));
     }
 
-    public function providerCreateWriter(): array
+    public static function providerCreateWriter(): array
     {
         return [
             ['Xls', Writer\Xls::class],
@@ -58,7 +58,7 @@ class IOFactoryTest extends TestCase
         self::assertSame($expected, get_class($actual));
     }
 
-    public function providerCreateReader(): array
+    public static function providerCreateReader(): array
     {
         return [
             ['Xls', Reader\Xls::class],
@@ -92,7 +92,7 @@ class IOFactoryTest extends TestCase
         self::assertInstanceOf(Spreadsheet::class, $actual);
     }
 
-    public function providerIdentify(): array
+    public static function providerIdentify(): array
     {
         return [
             ['samples/templates/26template.xlsx', 'Xlsx', Reader\Xlsx::class],

--- a/tests/PhpSpreadsheetTests/NamedRange2Test.php
+++ b/tests/PhpSpreadsheetTests/NamedRange2Test.php
@@ -102,7 +102,7 @@ class NamedRange2Test extends TestCase
         self::assertSame('yyyy-mm-dd', $sheet->getStyle('A1')->getNumberFormat()->getFormatCode());
     }
 
-    public function providerRangeOrFormula(): array
+    public static function providerRangeOrFormula(): array
     {
         return [
             'wrong sheet rel' => ['Invalid cell coordinate', 'SecondRel'],

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvEncodingTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvEncodingTest.php
@@ -40,7 +40,7 @@ class CsvEncodingTest extends TestCase
         self::assertEquals(2, $info[0]['totalColumns']);
     }
 
-    public function providerEncodings(): array
+    public static function providerEncodings(): array
     {
         return [
             ['tests/data/Reader/CSV/encoding.iso88591.csv', 'ISO-8859-1'],
@@ -98,7 +98,7 @@ class CsvEncodingTest extends TestCase
         self::assertEquals('sixième', $sheet->getCell('C2')->getValue());
     }
 
-    public function providerGuessEncoding(): array
+    public static function providerGuessEncoding(): array
     {
         return [
             ['tests/data/Reader/CSV/premiere.utf8.csv'],

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvIssue2232Test.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvIssue2232Test.php
@@ -55,7 +55,7 @@ class CsvIssue2232Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIssue2232(): array
+    public static function providerIssue2232(): array
     {
         return [
             [false, false, false, true],
@@ -94,7 +94,7 @@ class CsvIssue2232Test extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerIssue2232locale(): array
+    public static function providerIssue2232locale(): array
     {
         return [
             [true, true, 'Faux', 'Vrai'],

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvLineEndingTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvLineEndingTest.php
@@ -61,7 +61,7 @@ class CsvLineEndingTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerEndings(): array
+    public static function providerEndings(): array
     {
         return [
             'Unix endings' => ["\n"],

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvNumberFormatLocaleTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvNumberFormatLocaleTest.php
@@ -71,7 +71,7 @@ class CsvNumberFormatLocaleTest extends TestCase
         self::assertSame($expectedFormat, $cell->getFormattedValue(), 'Format mask check');
     }
 
-    public function providerNumberFormatNoConversionTest(): array
+    public static function providerNumberFormatNoConversionTest(): array
     {
         return [
             [
@@ -115,7 +115,7 @@ class CsvNumberFormatLocaleTest extends TestCase
         self::assertSame($expectedValue, $cell->getValue(), 'Expected value check');
     }
 
-    public function providerNumberValueConversionTest(): array
+    public static function providerNumberValueConversionTest(): array
     {
         return [
             'A1' => [

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvNumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvNumberFormatTest.php
@@ -40,7 +40,7 @@ class CsvNumberFormatTest extends TestCase
         self::assertSame($expectedFormat, $cell->getFormattedValue(), 'Format mask check');
     }
 
-    public function providerNumberFormatNoConversionTest(): array
+    public static function providerNumberFormatNoConversionTest(): array
     {
         return [
             [
@@ -78,7 +78,7 @@ class CsvNumberFormatTest extends TestCase
         self::assertSame($expectedValue, $cell->getValue(), 'Expected value check');
     }
 
-    public function providerNumberValueConversionTest(): array
+    public static function providerNumberValueConversionTest(): array
     {
         return [
             'A1' => [
@@ -130,7 +130,7 @@ class CsvNumberFormatTest extends TestCase
         self::assertSame($expectedFormat, $cell->getFormattedValue(), 'Format mask check');
     }
 
-    public function providerNumberFormatConversionTest(): array
+    public static function providerNumberFormatConversionTest(): array
     {
         return [
             'A1' => [

--- a/tests/PhpSpreadsheetTests/Reader/Csv/CsvTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Csv/CsvTest.php
@@ -30,7 +30,7 @@ class CsvTest extends TestCase
         self::assertSame($expectedValue, $actual, 'should be able to retrieve correct value');
     }
 
-    public function providerDelimiterDetection(): array
+    public static function providerDelimiterDetection(): array
     {
         return [
             [
@@ -102,7 +102,7 @@ class CsvTest extends TestCase
         self::assertSame($expected, $reader->canRead($filename));
     }
 
-    public function providerCanLoad(): array
+    public static function providerCanLoad(): array
     {
         return [
             [false, 'tests/data/Reader/Ods/data.ods'],
@@ -243,7 +243,7 @@ class CsvTest extends TestCase
         self::assertEquals($delimiter, $reader->getDelimiter());
     }
 
-    public function providerEscapes(): array
+    public static function providerEscapes(): array
     {
         return [
             ['\\', ';'],
@@ -266,7 +266,7 @@ class CsvTest extends TestCase
         self::assertSame($setNull, $reader->getDelimiter());
     }
 
-    public function providerNull(): array
+    public static function providerNull(): array
     {
         return [
             [null],

--- a/tests/PhpSpreadsheetTests/Reader/Gnumeric/GnumericStylesTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Gnumeric/GnumericStylesTest.php
@@ -176,7 +176,7 @@ class GnumericStylesTest extends TestCase
         }
     }
 
-    public function providerBorderStyle(): array
+    public static function providerBorderStyle(): array
     {
         return [
             ['0', Border::BORDER_NONE],
@@ -196,7 +196,7 @@ class GnumericStylesTest extends TestCase
         ];
     }
 
-    public function providerFillType(): array
+    public static function providerFillType(): array
     {
         return [
             ['1', Fill::FILL_SOLID],
@@ -220,7 +220,7 @@ class GnumericStylesTest extends TestCase
         ];
     }
 
-    public function providerHorizontal(): array
+    public static function providerHorizontal(): array
     {
         return [
             ['1', Alignment::HORIZONTAL_GENERAL],
@@ -233,7 +233,7 @@ class GnumericStylesTest extends TestCase
         ];
     }
 
-    public function providerUnderline(): array
+    public static function providerUnderline(): array
     {
         return [
             ['1', Font::UNDERLINE_SINGLE],
@@ -243,7 +243,7 @@ class GnumericStylesTest extends TestCase
         ];
     }
 
-    public function providerVertical(): array
+    public static function providerVertical(): array
     {
         return [
             ['1', Alignment::VERTICAL_TOP],
@@ -253,7 +253,7 @@ class GnumericStylesTest extends TestCase
         ];
     }
 
-    public function providerDataType(): array
+    public static function providerDataType(): array
     {
         return [
             ['10', DataType::TYPE_NULL],

--- a/tests/PhpSpreadsheetTests/Reader/Html/HtmlBorderTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Html/HtmlBorderTest.php
@@ -101,7 +101,7 @@ class HtmlBorderTest extends TestCase
         }
     }
 
-    public function providerBorderStyle(): array
+    public static function providerBorderStyle(): array
     {
         return [
             ['dash-dot', Border::BORDER_DASHDOT],

--- a/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Security/XmlScannerTest.php
@@ -42,7 +42,7 @@ class XmlScannerTest extends TestCase
         }
     }
 
-    public function providerValidXML(): array
+    public static function providerValidXML(): array
     {
         $tests = [];
         $glob = glob('tests/data/Reader/Xml/XEETestValid*.xml');
@@ -81,7 +81,7 @@ class XmlScannerTest extends TestCase
         }
     }
 
-    public function providerInvalidXML(): array
+    public static function providerInvalidXML(): array
     {
         $tests = [];
         $glob = glob('tests/data/Reader/Xml/XEETestInvalidUTF*.xml');
@@ -138,7 +138,7 @@ class XmlScannerTest extends TestCase
         self::assertEquals(strrev($expectedResult), $xml);
     }
 
-    public function providerValidXMLForCallback(): array
+    public static function providerValidXMLForCallback(): array
     {
         $tests = [];
         $glob = glob('tests/data/Reader/Xml/SecurityScannerWithCallback*.xml');

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ColorMapTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ColorMapTest.php
@@ -19,7 +19,7 @@ class ColorMapTest extends TestCase
         self::assertSame($expectedBuiltin, BuiltIn::lookup($index)['rgb']);
     }
 
-    public function colorMapProvider(): array
+    public static function colorMapProvider(): array
     {
         return [
             'default builtin' => [0x00, '000000', '000000', '000000'],

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ConditionalFormattingBasicTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ConditionalFormattingBasicTest.php
@@ -31,7 +31,7 @@ class ConditionalFormattingBasicTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function conditionalFormattingProvider(): array
+    public static function conditionalFormattingProvider(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ConditionalFormattingExpressionTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ConditionalFormattingExpressionTest.php
@@ -30,7 +30,7 @@ class ConditionalFormattingExpressionTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function conditionalFormattingProvider(): array
+    public static function conditionalFormattingProvider(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Reader/Xls/DataValidationTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/DataValidationTest.php
@@ -27,7 +27,7 @@ class DataValidationTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function dataValidationProvider(): array
+    public static function dataValidationProvider(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Reader/Xls/ErrorCodeMapTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xls/ErrorCodeMapTest.php
@@ -17,7 +17,7 @@ class ErrorCodeMapTest extends TestCase
         self::assertSame($expected, ErrorCode::lookup($index));
     }
 
-    public function errorCodeMapProvider(): array
+    public static function errorCodeMapProvider(): array
     {
         return [
             [false, 0x01],

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/AutoFilterTest.php
@@ -20,7 +20,7 @@ class AutoFilterTest extends TestCase
         );
     }
 
-    public function loadDataProvider(): array
+    public static function loadDataProvider(): array
     {
         return [
             ['$B3$E8', 0, 'B3E8'],

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/DataValidationTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/DataValidationTest.php
@@ -47,7 +47,7 @@ class DataValidationTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerExternalSheet(): array
+    public static function providerExternalSheet(): array
     {
         return [
             'standard spreadsheet' => ['Feuil2!$A$3:$A$5', 'tests/data/Reader/XLSX/dataValidation2Test.xlsx'],

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/DirectorySeparatorTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/DirectorySeparatorTest.php
@@ -61,7 +61,7 @@ class DirectorySeparatorTest extends TestCase
         self::assertSame('Key ID', $cellValue);
     }
 
-    public function providerDirectorySeparator(): array
+    public static function providerDirectorySeparator(): array
     {
         return [
             ['Zip-Linux-Directory-Separator.xlsx'],

--- a/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xlsx/XlsxTest.php
@@ -232,7 +232,7 @@ class XlsxTest extends TestCase
         self::assertEquals(preg_match('/\s/', $string), 0);
     }
 
-    public function providerStripsWhiteSpaceFromStyleString(): array
+    public static function providerStripsWhiteSpaceFromStyleString(): array
     {
         return [
             ['position:absolute;margin-left:424.5pt;margin-top:169.5pt;width:67.5pt;

--- a/tests/PhpSpreadsheetTests/Reader/Xml/XmlStyleCoverageTest.php
+++ b/tests/PhpSpreadsheetTests/Reader/Xml/XmlStyleCoverageTest.php
@@ -63,7 +63,7 @@ class XmlStyleCoverageTest extends TestCase
         }
     }
 
-    public function providerBorderStyle(): array
+    public static function providerBorderStyle(): array
     {
         return [
             ['1continuous', Border::BORDER_THIN],
@@ -87,7 +87,7 @@ class XmlStyleCoverageTest extends TestCase
         ];
     }
 
-    public function providerFillType(): array
+    public static function providerFillType(): array
     {
         return [
             ['solid', Fill::FILL_SOLID],

--- a/tests/PhpSpreadsheetTests/RefRangeTest.php
+++ b/tests/PhpSpreadsheetTests/RefRangeTest.php
@@ -22,7 +22,7 @@ class RefRangeTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function providerRefRange(): array
+    public static function providerRefRange(): array
     {
         return [
             'normal range' => [0, 'B1:B2'],

--- a/tests/PhpSpreadsheetTests/ReferenceHelperTest.php
+++ b/tests/PhpSpreadsheetTests/ReferenceHelperTest.php
@@ -113,7 +113,7 @@ class ReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerFormulaUpdates(): array
+    public static function providerFormulaUpdates(): array
     {
         return require 'tests/data/ReferenceHelperFormulaUpdates.php';
     }
@@ -130,7 +130,7 @@ class ReferenceHelperTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerMultipleWorksheetFormulaUpdates(): array
+    public static function providerMultipleWorksheetFormulaUpdates(): array
     {
         return require 'tests/data/ReferenceHelperFormulaUpdatesMultipleSheet.php';
     }

--- a/tests/PhpSpreadsheetTests/Shared/CodePageTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/CodePageTest.php
@@ -27,7 +27,7 @@ class CodePageTest extends TestCase
         }
     }
 
-    public function providerCodePage(): array
+    public static function providerCodePage(): array
     {
         return require 'tests/data/Shared/CodePage.php';
     }

--- a/tests/PhpSpreadsheetTests/Shared/Date2Test.php
+++ b/tests/PhpSpreadsheetTests/Shared/Date2Test.php
@@ -63,7 +63,7 @@ class Date2Test extends TestCase
         self::assertSame(1, $this->spreadsheet->getActiveSheetIndex());
     }
 
-    public function providerTimeOnly(): array
+    public static function providerTimeOnly(): array
     {
         $integerValue = 44046;
         $integerValueAsFloat = (float) $integerValue;
@@ -112,7 +112,7 @@ class Date2Test extends TestCase
         self::assertSame(1, $this->spreadsheet->getActiveSheetIndex());
     }
 
-    public function providerDateAndTime(): array
+    public static function providerDateAndTime(): array
     {
         $integerValue = 44046;
         $integerValueAsFloat = (float) $integerValue;
@@ -187,7 +187,7 @@ class Date2Test extends TestCase
         self::assertSame(1, $this->spreadsheet->getActiveSheetIndex());
     }
 
-    public function providerAsis(): array
+    public static function providerAsis(): array
     {
         $integerValue = 44046;
         $integerValueAsFloat = (float) $integerValue;

--- a/tests/PhpSpreadsheetTests/Shared/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DateTest.php
@@ -69,7 +69,7 @@ class DateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDateTimeExcelToTimestamp1900(): array
+    public static function providerDateTimeExcelToTimestamp1900(): array
     {
         return require 'tests/data/Shared/Date/ExcelToTimestamp1900.php';
     }
@@ -88,7 +88,7 @@ class DateTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-5);
     }
 
-    public function providerDateTimeTimestampToExcel1900(): array
+    public static function providerDateTimeTimestampToExcel1900(): array
     {
         return require 'tests/data/Shared/Date/TimestampToExcel1900.php';
     }
@@ -107,7 +107,7 @@ class DateTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-5);
     }
 
-    public function providerDateTimeDateTimeToExcel(): array
+    public static function providerDateTimeDateTimeToExcel(): array
     {
         return require 'tests/data/Shared/Date/DateTimeToExcel.php';
     }
@@ -125,7 +125,7 @@ class DateTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-5);
     }
 
-    public function providerDateTimeFormattedPHPToExcel1900(): array
+    public static function providerDateTimeFormattedPHPToExcel1900(): array
     {
         return require 'tests/data/Shared/Date/FormattedPHPToExcel1900.php';
     }
@@ -147,7 +147,7 @@ class DateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDateTimeExcelToTimestamp1904(): array
+    public static function providerDateTimeExcelToTimestamp1904(): array
     {
         return require 'tests/data/Shared/Date/ExcelToTimestamp1904.php';
     }
@@ -166,7 +166,7 @@ class DateTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, 1E-5);
     }
 
-    public function providerDateTimeTimestampToExcel1904(): array
+    public static function providerDateTimeTimestampToExcel1904(): array
     {
         return require 'tests/data/Shared/Date/TimestampToExcel1904.php';
     }
@@ -182,7 +182,7 @@ class DateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerIsDateTimeFormatCode(): array
+    public static function providerIsDateTimeFormatCode(): array
     {
         return require 'tests/data/Shared/Date/FormatCodes.php';
     }
@@ -205,7 +205,7 @@ class DateTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerDateTimeExcelToTimestamp1900Timezone(): array
+    public static function providerDateTimeExcelToTimestamp1900Timezone(): array
     {
         return require 'tests/data/Shared/Date/ExcelToTimestamp1900Timezone.php';
     }

--- a/tests/PhpSpreadsheetTests/Shared/DrawingTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/DrawingTest.php
@@ -42,7 +42,7 @@ class DrawingTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerPixelsToCellDimension(): array
+    public static function providerPixelsToCellDimension(): array
     {
         return [
             [19.9951171875, 100, 'Arial', 7],
@@ -60,7 +60,7 @@ class DrawingTest extends TestCase
         ];
     }
 
-    public function providerCellDimensionToPixels(): array
+    public static function providerCellDimensionToPixels(): array
     {
         return [
             [500, 100, 'Arial', 7],

--- a/tests/PhpSpreadsheetTests/Shared/ExactFontTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/ExactFontTest.php
@@ -105,7 +105,7 @@ class ExactFontTest extends TestCase
         }
     }
 
-    public function providerFontData(): array
+    public static function providerFontData(): array
     {
         return [
             ['DejaVu Sans', 19.82, 20.453125, 22.5659, 21.709],

--- a/tests/PhpSpreadsheetTests/Shared/Font2Test.php
+++ b/tests/PhpSpreadsheetTests/Shared/Font2Test.php
@@ -40,7 +40,7 @@ class Font2Test extends TestCase
         self::assertTrue($defaultCovered, 'Default key not tested');
     }
 
-    public function providerCharsetFromFontName(): array
+    public static function providerCharsetFromFontName(): array
     {
         return [
             ['EucrosiaUPC', Font::CHARSET_ANSI_THAI],

--- a/tests/PhpSpreadsheetTests/Shared/FontFileNameTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/FontFileNameTest.php
@@ -53,7 +53,7 @@ class FontFileNameTest extends TestCase
         self::assertSame($expected, basename($result));
     }
 
-    public function providerDefault(): array
+    public static function providerDefault(): array
     {
         return [
             ['arial.ttf', ['name' => 'Arial']],
@@ -95,7 +95,7 @@ class FontFileNameTest extends TestCase
         self::assertSame($expected, ucfirst(basename($result))); // allow for Windows case-insensitivity
     }
 
-    public function providerMac(): array
+    public static function providerMac(): array
     {
         return [
             ['Arial.ttf', ['name' => 'Arial']],
@@ -141,7 +141,7 @@ class FontFileNameTest extends TestCase
         self::assertSame($expected, basename($result));
     }
 
-    public function providerOverride(): array
+    public static function providerOverride(): array
     {
         return [
             ['extrafont.ttf', ['name' => 'Arial']],
@@ -172,7 +172,7 @@ class FontFileNameTest extends TestCase
         self::assertSame($expected, basename($result));
     }
 
-    public function providerOverrideAbsolute(): array
+    public static function providerOverrideAbsolute(): array
     {
         return [
             'absolute path normal' => ['Arial.ttf', ['name' => 'Arial']],

--- a/tests/PhpSpreadsheetTests/Shared/FontTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/FontTest.php
@@ -51,7 +51,7 @@ class FontTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerFontSizeToPixels(): array
+    public static function providerFontSizeToPixels(): array
     {
         return require 'tests/data/Shared/FontSizeToPixels.php';
     }
@@ -68,7 +68,7 @@ class FontTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::FONT_PRECISION);
     }
 
-    public function providerInchSizeToPixels(): array
+    public static function providerInchSizeToPixels(): array
     {
         return require 'tests/data/Shared/InchSizeToPixels.php';
     }
@@ -85,7 +85,7 @@ class FontTest extends TestCase
         self::assertEqualsWithDelta($expectedResult, $result, self::FONT_PRECISION);
     }
 
-    public function providerCentimeterSizeToPixels(): array
+    public static function providerCentimeterSizeToPixels(): array
     {
         return require 'tests/data/Shared/CentimeterSizeToPixels.php';
     }
@@ -118,7 +118,7 @@ class FontTest extends TestCase
         self::assertEquals($expectedWidth, $columnWidth);
     }
 
-    public function providerCalculateApproximateColumnWidth(): array
+    public static function providerCalculateApproximateColumnWidth(): array
     {
         return [
             [13.9966, new StyleFont(), 'Hello World', 0, new StyleFont(), false, 0],

--- a/tests/PhpSpreadsheetTests/Shared/PasswordHasherTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/PasswordHasherTest.php
@@ -33,7 +33,7 @@ class PasswordHasherTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerHashPassword(): array
+    public static function providerHashPassword(): array
     {
         return require 'tests/data/Shared/PasswordHashes.php';
     }

--- a/tests/PhpSpreadsheetTests/Shared/PasswordReloadTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/PasswordReloadTest.php
@@ -39,7 +39,7 @@ class PasswordReloadTest extends AbstractFunctional
         $reloadedSpreadsheet->disconnectWorksheets();
     }
 
-    public function providerPasswords(): array
+    public static function providerPasswords(): array
     {
         return [
             'Xls basic algorithm' => ['Xls', ''],

--- a/tests/PhpSpreadsheetTests/Shared/Trend/ExponentialBestFitTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/Trend/ExponentialBestFitTest.php
@@ -42,7 +42,7 @@ class ExponentialBestFitTest extends TestCase
         self::assertSame($expectedGoodnessOfFit[1], $bestFit->getGoodnessOfFit());
     }
 
-    public function providerExponentialBestFit(): array
+    public static function providerExponentialBestFit(): array
     {
         return require 'tests/data/Shared/Trend/ExponentialBestFit.php';
     }

--- a/tests/PhpSpreadsheetTests/Shared/Trend/LinearBestFitTest.php
+++ b/tests/PhpSpreadsheetTests/Shared/Trend/LinearBestFitTest.php
@@ -44,7 +44,7 @@ class LinearBestFitTest extends TestCase
         self::assertSame($expectedGoodnessOfFit[1], $bestFit->getGoodnessOfFit());
     }
 
-    public function providerLinearBestFit(): array
+    public static function providerLinearBestFit(): array
     {
         return require 'tests/data/Shared/Trend/LinearBestFit.php';
     }

--- a/tests/PhpSpreadsheetTests/SpreadsheetTest.php
+++ b/tests/PhpSpreadsheetTests/SpreadsheetTest.php
@@ -36,7 +36,7 @@ class SpreadsheetTest extends TestCase
         return $spreadsheet;
     }
 
-    public function dataProviderForSheetNames(): array
+    public static function dataProviderForSheetNames(): array
     {
         $array = [
             [0, 'someSheet1'],

--- a/tests/PhpSpreadsheetTests/Style/ColorIndexTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ColorIndexTest.php
@@ -22,7 +22,7 @@ class ColorIndexTest extends TestCase
         }
     }
 
-    public function providerColorIndexes(): array
+    public static function providerColorIndexes(): array
     {
         return [
             'subtract 7 to return system color 4' => ['FF00FF00', '<fgColor indexed="11"/>'],

--- a/tests/PhpSpreadsheetTests/Style/ColorTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ColorTest.php
@@ -89,7 +89,7 @@ class ColorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerColorGetRed(): array
+    public static function providerColorGetRed(): array
     {
         return require 'tests/data/Style/Color/ColorGetRed.php';
     }
@@ -109,7 +109,7 @@ class ColorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerColorGetGreen(): array
+    public static function providerColorGetGreen(): array
     {
         return require 'tests/data/Style/Color/ColorGetGreen.php';
     }
@@ -129,7 +129,7 @@ class ColorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerColorGetBlue(): array
+    public static function providerColorGetBlue(): array
     {
         return require 'tests/data/Style/Color/ColorGetBlue.php';
     }
@@ -145,7 +145,7 @@ class ColorTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerColorChangeBrightness(): array
+    public static function providerColorChangeBrightness(): array
     {
         return require 'tests/data/Style/Color/ColorChangeBrightness.php';
     }

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/CellMatcherTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/CellMatcherTest.php
@@ -63,7 +63,7 @@ class CellMatcherTest extends TestCase
         }
     }
 
-    public function basicCellIsComparisonDataProvider(): array
+    public static function basicCellIsComparisonDataProvider(): array
     {
         return [
             // Less than/Equal/Greater than with Literal
@@ -131,7 +131,7 @@ class CellMatcherTest extends TestCase
         self::assertSame($expectedMatch, $match);
     }
 
-    public function rangeCellIsComparisonDataProvider(): array
+    public static function rangeCellIsComparisonDataProvider(): array
     {
         return [
             // Range between Literals
@@ -174,7 +174,7 @@ class CellMatcherTest extends TestCase
         }
     }
 
-    public function cellIsExpressionMultipleDataProvider(): array
+    public static function cellIsExpressionMultipleDataProvider(): array
     {
         return [
             // Odd/Even
@@ -206,7 +206,7 @@ class CellMatcherTest extends TestCase
         self::assertSame($expectedMatch, $match);
     }
 
-    public function cellIsExpressionDataProvider(): array
+    public static function cellIsExpressionDataProvider(): array
     {
         return [
             // Sales Grid for Country
@@ -250,7 +250,7 @@ class CellMatcherTest extends TestCase
         self::assertSame($expectedMatch, $match);
     }
 
-    public function textExpressionsDataProvider(): array
+    public static function textExpressionsDataProvider(): array
     {
         return [
             // Text Begins With Literal
@@ -360,7 +360,7 @@ class CellMatcherTest extends TestCase
         }
     }
 
-    public function blanksDataProvider(): array
+    public static function blanksDataProvider(): array
     {
         return [
             // Blank/Not Blank
@@ -391,7 +391,7 @@ class CellMatcherTest extends TestCase
         }
     }
 
-    public function errorDataProvider(): array
+    public static function errorDataProvider(): array
     {
         return [
             // Error/Not Error
@@ -419,7 +419,7 @@ class CellMatcherTest extends TestCase
         self::assertSame($expectedMatch, $match);
     }
 
-    public function dateOccurringDataProvider(): array
+    public static function dateOccurringDataProvider(): array
     {
         return [
             // Today
@@ -463,7 +463,7 @@ class CellMatcherTest extends TestCase
         }
     }
 
-    public function duplicatesDataProvider(): array
+    public static function duplicatesDataProvider(): array
     {
         return [
             // Duplicate/Unique
@@ -495,7 +495,7 @@ class CellMatcherTest extends TestCase
         self::assertSame($expectedMatch, $match);
     }
 
-    public function textCrossWorksheetDataProvider(): array
+    public static function textCrossWorksheetDataProvider(): array
     {
         return [
             // Relative Cell References in another Worksheet

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/CellValueWizardTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/CellValueWizardTest.php
@@ -57,7 +57,7 @@ class CellValueWizardTest extends TestCase
         self::assertEquals($newWizard, $wizard, 'fromConditional() Failure');
     }
 
-    public function basicCellValueDataProvider(): array
+    public static function basicCellValueDataProvider(): array
     {
         return [
             '=5' => ['equals', 5, Conditional::OPERATOR_EQUAL, 5],
@@ -97,7 +97,7 @@ class CellValueWizardTest extends TestCase
         self::assertEquals($newWizard, $wizard, 'fromConditional() Failure');
     }
 
-    public function relativeCellValueDataProvider(): array
+    public static function relativeCellValueDataProvider(): array
     {
         return [
             '= Cell value unpinned' => ['A1', 'C3'],
@@ -131,7 +131,7 @@ class CellValueWizardTest extends TestCase
         self::assertEquals($newWizard, $wizard, 'fromConditional() Failure');
     }
 
-    public function formulaCellValueDataProvider(): array
+    public static function formulaCellValueDataProvider(): array
     {
         return [
             '= Cell value unpinned in function' => ['SQRT(A1)', 'SQRT(C3)'],
@@ -168,7 +168,7 @@ class CellValueWizardTest extends TestCase
         self::assertEquals($newWizard, $wizard, 'fromConditional() Failure');
     }
 
-    public function rangeCellValueDataProvider(): array
+    public static function rangeCellValueDataProvider(): array
     {
         return [
             'between 5 and 10' => ['between', [5, 10], Conditional::OPERATOR_BETWEEN],
@@ -201,7 +201,7 @@ class CellValueWizardTest extends TestCase
         self::assertEquals($newWizard, $wizard, 'fromConditional() Failure');
     }
 
-    public function rangeRelativeCellValueDataProvider(): array
+    public static function rangeRelativeCellValueDataProvider(): array
     {
         return [
             'between A6 and 5' => [['A$6', 5], ['C$6', 5]],
@@ -233,7 +233,7 @@ class CellValueWizardTest extends TestCase
         self::assertEquals($newWizard, $wizard, 'fromConditional() Failure');
     }
 
-    public function rangeFormulaCellValueDataProvider(): array
+    public static function rangeFormulaCellValueDataProvider(): array
     {
         return [
             'between yesterday and tomorrow' => [['TODAY()-1', 'TODAY()+1'], ['TODAY()-1', 'TODAY()+1']],

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/DateValueWizardTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/DateValueWizardTest.php
@@ -54,7 +54,7 @@ class DateValueWizardTest extends TestCase
         self::assertEquals($newWizard, $dateWizard, 'fromConditional() Failure');
     }
 
-    public function dateValueWizardProvider(): array
+    public static function dateValueWizardProvider(): array
     {
         return [
             ['today', 'today', 'FLOOR(C3,1)=TODAY()'],

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/ExpressionWizardTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/ExpressionWizardTest.php
@@ -71,7 +71,7 @@ class ExpressionWizardTest extends TestCase
         self::assertSame([$expectedExpression], $conditions);
     }
 
-    public function expressionDataProvider(): array
+    public static function expressionDataProvider(): array
     {
         return [
             ['ISODD(A1)', 'ISODD(C3)'],

--- a/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/WizardFactoryTest.php
+++ b/tests/PhpSpreadsheetTests/Style/ConditionalFormatting/Wizard/WizardFactoryTest.php
@@ -32,7 +32,7 @@ class WizardFactoryTest extends TestCase
         self::assertInstanceOf($expectedWizard, $wizard);
     }
 
-    public function basicWizardFactoryProvider(): array
+    public static function basicWizardFactoryProvider(): array
     {
         return [
             'CellValue Wizard' => [Wizard::CELL_VALUE, Wizard\CellValue::class],
@@ -69,7 +69,7 @@ class WizardFactoryTest extends TestCase
         }
     }
 
-    public function conditionalProvider(): array
+    public static function conditionalProvider(): array
     {
         return [
             'cellIs Comparison A2' => ['cellIs Comparison', 'A2', [Wizard\CellValue::class, Wizard\CellValue::class, Wizard\CellValue::class]],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/AccountingTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/AccountingTest.php
@@ -26,7 +26,7 @@ class AccountingTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerAccounting(): array
+    public static function providerAccounting(): array
     {
         return [
             ["_-$*\u{a0}0_-", '$', 0, Number::WITHOUT_THOUSANDS_SEPARATOR, Currency::LEADING_SYMBOL, Currency::SYMBOL_WITH_SPACING],
@@ -55,7 +55,7 @@ class AccountingTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerAccountingLocale(): array
+    public static function providerAccountingLocale(): array
     {
         return [
             ["[\$€-fy-NL]\u{a0}#,##0.00;([\$€-fy-NL]\u{a0}#,##0.00)", '€', 'fy-NL'],
@@ -87,7 +87,7 @@ class AccountingTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerAccountingLocaleNoDecimals(): array
+    public static function providerAccountingLocaleNoDecimals(): array
     {
         return [
             ["[\$€-fy-NL]\u{a0}#,##0;([\$€-fy-NL]\u{a0}#,##0)", '€', 'fy-NL'],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/CurrencyTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/CurrencyTest.php
@@ -25,7 +25,7 @@ class CurrencyTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerCurrency(): array
+    public static function providerCurrency(): array
     {
         return [
             ["\$\u{a0}0", '$', 0, Number::WITHOUT_THOUSANDS_SEPARATOR, Currency::LEADING_SYMBOL, Currency::SYMBOL_WITH_SPACING],
@@ -54,7 +54,7 @@ class CurrencyTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerCurrencyLocale(): array
+    public static function providerCurrencyLocale(): array
     {
         return [
             ["[\$€-fy-NL]\u{a0}#,##0.00;[\$€-fy-NL]\u{a0}#,##0.00-", '€', 'fy-NL'], // Trailing negative
@@ -86,7 +86,7 @@ class CurrencyTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerCurrencyLocaleNoDecimals(): array
+    public static function providerCurrencyLocaleNoDecimals(): array
     {
         return [
             ["[\$€-fy-NL]\u{a0}#,##0;[\$€-fy-NL]\u{a0}#,##0-", '€', 'fy-NL'], // Trailing negative

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/DateTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/DateTest.php
@@ -19,7 +19,7 @@ class DateTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerDate(): array
+    public static function providerDate(): array
     {
         return [
             ['yyyy-mm-dd', Date::SEPARATOR_DASH, [Date::YEAR_FULL, Date::MONTH_NUMBER_LONG, Date::DAY_NUMBER_LONG]],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/DateTimeTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/DateTimeTest.php
@@ -21,7 +21,7 @@ class DateTimeTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerDateTime(): array
+    public static function providerDateTime(): array
     {
         return [
             ['yyyy-mm-dd "at" hh:mm:ss', ' ', [new Date('-', 'yyyy', 'mm', 'dd'), 'at', new Time(':', 'hh', 'mm', 'ss')]],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/DurationTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/DurationTest.php
@@ -19,7 +19,7 @@ class DurationTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerTime(): array
+    public static function providerTime(): array
     {
         return [
             ['[h]:mm:ss', Duration::SEPARATOR_COLON, [Duration::HOURS_DURATION, Duration::MINUTES_LONG, Duration::SECONDS_LONG]],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/NumberTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/NumberTest.php
@@ -18,7 +18,7 @@ class NumberTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerNumber(): array
+    public static function providerNumber(): array
     {
         return [
             ['0', 0, Number::WITHOUT_THOUSANDS_SEPARATOR],
@@ -46,7 +46,7 @@ class NumberTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerNumberLocale(): array
+    public static function providerNumberLocale(): array
     {
         return [
             ['#,##0.00', 'en-us'],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/PercentageTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/PercentageTest.php
@@ -18,7 +18,7 @@ class PercentageTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerPercentage(): array
+    public static function providerPercentage(): array
     {
         return [
             ['0%', 0],
@@ -46,7 +46,7 @@ class PercentageTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerPercentageLocale(): array
+    public static function providerPercentageLocale(): array
     {
         return [
             ['#,##0.00%', 'fy-NL'],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/ScientificTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/ScientificTest.php
@@ -18,7 +18,7 @@ class ScientificTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerScientific(): array
+    public static function providerScientific(): array
     {
         return [
             ['0E+00', 0],
@@ -46,7 +46,7 @@ class ScientificTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerScientificLocale(): array
+    public static function providerScientificLocale(): array
     {
         return [
             ['0.00E+00', 'en'],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/TimeTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormat/Wizard/TimeTest.php
@@ -19,7 +19,7 @@ class TimeTest extends TestCase
         self::assertSame($expectedResult, (string) $wizard);
     }
 
-    public function providerTime(): array
+    public static function providerTime(): array
     {
         return [
             ['hh:mm:ss', Time::SEPARATOR_COLON, [Time::HOURS_LONG, Time::MINUTES_LONG, Time::SECONDS_LONG]],

--- a/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Style/NumberFormatTest.php
@@ -51,7 +51,7 @@ class NumberFormatTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerNumberFormat(): array
+    public static function providerNumberFormat(): array
     {
         return require 'tests/data/Style/NumberFormat.php';
     }
@@ -68,7 +68,7 @@ class NumberFormatTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerNumberFormatFractions(): array
+    public static function providerNumberFormatFractions(): array
     {
         return require 'tests/data/Style/NumberFormatFractions.php';
     }
@@ -85,7 +85,7 @@ class NumberFormatTest extends TestCase
         self::assertEquals($expectedResult, $result);
     }
 
-    public function providerNumberFormatDates(): array
+    public static function providerNumberFormatDates(): array
     {
         return require 'tests/data/Style/NumberFormatDates.php';
     }
@@ -113,7 +113,7 @@ class NumberFormatTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function providerNoScientific(): array
+    public static function providerNoScientific(): array
     {
         return [
             'large number' => ['92' . str_repeat('0', 16), '9.2E+17'],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterAverageTop10Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterAverageTop10Test.php
@@ -26,7 +26,7 @@ class AutoFilterAverageTop10Test extends SetupTeardown
         return $sheet;
     }
 
-    public function providerAverage(): array
+    public static function providerAverage(): array
     {
         return [
             [[5, 6, 9, 10], Rule::AUTOFILTER_RULETYPE_DYNAMIC_ABOVEAVERAGE],
@@ -56,7 +56,7 @@ class AutoFilterAverageTop10Test extends SetupTeardown
         self::assertEquals($expectedVisible, $this->getVisible());
     }
 
-    public function providerTop10(): array
+    public static function providerTop10(): array
     {
         return [
             [[6, 10], Rule::AUTOFILTER_COLUMN_RULE_TOPTEN_BY_VALUE, Rule::AUTOFILTER_COLUMN_RULE_TOPTEN_TOP, 2],
@@ -106,7 +106,7 @@ class AutoFilterAverageTop10Test extends SetupTeardown
         return $sheet;
     }
 
-    public function providerTop10Ties(): array
+    public static function providerTop10Ties(): array
     {
         return [
             [[2, 3, 4], Rule::AUTOFILTER_COLUMN_RULE_TOPTEN_BY_VALUE, Rule::AUTOFILTER_COLUMN_RULE_TOPTEN_BOTTOM, 2],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterCustomNumericTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterCustomNumericTest.php
@@ -29,7 +29,7 @@ class AutoFilterCustomNumericTest extends SetupTeardown
         return $sheet;
     }
 
-    public function providerCustomRule(): array
+    public static function providerCustomRule(): array
     {
         return [
             'equal to 3' => [[3, 10], Rule::AUTOFILTER_COLUMN_RULE_EQUAL, 3],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterCustomTextTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterCustomTextTest.php
@@ -28,7 +28,7 @@ class AutoFilterCustomTextTest extends SetupTeardown
         return $sheet;
     }
 
-    public function providerCustomText(): array
+    public static function providerCustomText(): array
     {
         return [
             'begins with a' => [[2, 8], 'a*'],
@@ -177,7 +177,7 @@ class AutoFilterCustomTextTest extends SetupTeardown
         self::assertEquals([5, 11, 12], $this->getVisible());
     }
 
-    public function providerCustomRule(): array
+    public static function providerCustomRule(): array
     {
         return [
             'equal to cba' => [[3], Rule::AUTOFILTER_COLUMN_RULE_EQUAL, 'cba'],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterMonthTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterMonthTest.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class AutoFilterMonthTest extends SetupTeardown
 {
-    public function providerMonth(): array
+    public static function providerMonth(): array
     {
         return [
             [[2, 3], Rule::AUTOFILTER_RULETYPE_DYNAMIC_THISMONTH],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterQuarterTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterQuarterTest.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class AutoFilterQuarterTest extends SetupTeardown
 {
-    public function providerQuarter(): array
+    public static function providerQuarter(): array
     {
         return [
             [[2, 3], Rule::AUTOFILTER_RULETYPE_DYNAMIC_THISQUARTER],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTodayTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterTodayTest.php
@@ -8,7 +8,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule;
 
 class AutoFilterTodayTest extends SetupTeardown
 {
-    public function providerYesterdayTodayTomorrow(): array
+    public static function providerYesterdayTodayTomorrow(): array
     {
         return [
             [[2, 5], Rule::AUTOFILTER_RULETYPE_DYNAMIC_TODAY],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterWeekTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterWeekTest.php
@@ -9,7 +9,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class AutoFilterWeekTest extends SetupTeardown
 {
-    public function providerWeek(): array
+    public static function providerWeek(): array
     {
         return [
             [[2, 3], Rule::AUTOFILTER_RULETYPE_DYNAMIC_THISWEEK],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterYearTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/AutoFilterYearTest.php
@@ -8,7 +8,7 @@ use PhpOffice\PhpSpreadsheet\Worksheet\AutoFilter\Column\Rule;
 
 class AutoFilterYearTest extends SetupTeardown
 {
-    public function providerYear(): array
+    public static function providerYear(): array
     {
         return [
             [[5, 6, 7], Rule::AUTOFILTER_RULETYPE_DYNAMIC_THISYEAR],

--- a/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/RuleCustomTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/AutoFilter/RuleCustomTest.php
@@ -43,7 +43,7 @@ class RuleCustomTest extends SetupTeardown
         self::assertEquals($expectedResult, $this->getVisible());
     }
 
-    public function providerCondition(): array
+    public static function providerCondition(): array
     {
         return [
             [[3], Rule::AUTOFILTER_COLUMN_RULE_EQUAL],

--- a/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIterator2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ColumnCellIterator2Test.php
@@ -37,7 +37,7 @@ class ColumnCellIterator2Test extends TestCase
         self::assertSame($expectedResultLast, $lastCoordinate);
     }
 
-    public function providerExistingCell(): array
+    public static function providerExistingCell(): array
     {
         return [
             [null, 'B1', 'B8'],
@@ -67,7 +67,7 @@ class ColumnCellIterator2Test extends TestCase
         self::assertSame($expectedResult, $numCells);
     }
 
-    public function providerEmptyColumn(): array
+    public static function providerEmptyColumn(): array
     {
         return [
             [null, 6], // Default behaviour
@@ -115,7 +115,7 @@ class ColumnCellIterator2Test extends TestCase
         self::assertSame($expectedNullResult, $numEmptyCells);
     }
 
-    public function providerNullOrCreate(): array
+    public static function providerNullOrCreate(): array
     {
         return [
             [null, 3, 0], // Default behaviour

--- a/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/ConditionalStyleTest.php
@@ -75,7 +75,7 @@ class ConditionalStyleTest extends TestCase
         self::assertSame($expectedGetConditionalStyles, !empty($cellHasConditionalStyles));
     }
 
-    public function cellConditionalStylesProvider(): array
+    public static function cellConditionalStylesProvider(): array
     {
         return [
             ['A1', true],

--- a/tests/PhpSpreadsheetTests/Worksheet/PageMarginsTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/PageMarginsTest.php
@@ -61,7 +61,7 @@ class PageMarginsTest extends TestCase
         self::assertSame($expectedResult, $actualResult);
     }
 
-    public function providerPointsAndInches(): array
+    public static function providerPointsAndInches(): array
     {
         return [
             [36, 0.5],
@@ -71,7 +71,7 @@ class PageMarginsTest extends TestCase
         ];
     }
 
-    public function providerCentimetersAndInches(): array
+    public static function providerCentimetersAndInches(): array
     {
         return [
             [1.27, 0.5],
@@ -79,7 +79,7 @@ class PageMarginsTest extends TestCase
         ];
     }
 
-    public function providerMillimetersAndInches(): array
+    public static function providerMillimetersAndInches(): array
     {
         return [
             [12.7, 0.5],

--- a/tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/RowCellIterator2Test.php
@@ -37,7 +37,7 @@ class RowCellIterator2Test extends TestCase
         self::assertSame($expectedResultLast, $lastCoordinate);
     }
 
-    public function providerExistingCell(): array
+    public static function providerExistingCell(): array
     {
         return [
             [null, 'B2', 'H2'],
@@ -67,7 +67,7 @@ class RowCellIterator2Test extends TestCase
         self::assertSame($expectedResult, $numCells);
     }
 
-    public function providerEmptyRow(): array
+    public static function providerEmptyRow(): array
     {
         return [
             [null, 6], // Default behaviour
@@ -115,7 +115,7 @@ class RowCellIterator2Test extends TestCase
         self::assertSame($expectedNullResult, $numEmptyCells);
     }
 
-    public function providerNullOrCreate(): array
+    public static function providerNullOrCreate(): array
     {
         return [
             [null, 4, 0], // Default behaviour

--- a/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
+++ b/tests/PhpSpreadsheetTests/Worksheet/WorksheetTest.php
@@ -24,7 +24,7 @@ class WorksheetTest extends TestCase
         self::assertSame($testTitle, $worksheet->getTitle());
     }
 
-    public function setTitleInvalidProvider(): array
+    public static function setTitleInvalidProvider(): array
     {
         return [
             [str_repeat('a', 32), 'Maximum 31 characters allowed in sheet title.'],
@@ -83,7 +83,7 @@ class WorksheetTest extends TestCase
         self::assertSame($testCodeName, $worksheet->getCodeName());
     }
 
-    public function setCodeNameInvalidProvider(): array
+    public static function setCodeNameInvalidProvider(): array
     {
         return [
             [str_repeat('a', 32), 'Maximum 31 characters allowed in sheet code name.'],
@@ -141,7 +141,7 @@ class WorksheetTest extends TestCase
         self::assertSame('B2', $worksheet->getTopLeftCell());
     }
 
-    public function extractSheetTitleProvider(): array
+    public static function extractSheetTitleProvider(): array
     {
         return [
             ['B2', '', '', 'B2'],
@@ -193,7 +193,7 @@ class WorksheetTest extends TestCase
         );
     }
 
-    public function removeColumnProvider(): array
+    public static function removeColumnProvider(): array
     {
         return [
             'Remove first column' => [
@@ -284,7 +284,7 @@ class WorksheetTest extends TestCase
         self::assertSame($expectedData, $worksheet->toArray());
     }
 
-    public function removeRowsProvider(): array
+    public static function removeRowsProvider(): array
     {
         return [
             'Remove all rows except first one' => [
@@ -468,7 +468,7 @@ class WorksheetTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function emptyRowProvider(): array
+    public static function emptyRowProvider(): array
     {
         return [
             [1, false],
@@ -497,7 +497,7 @@ class WorksheetTest extends TestCase
         $spreadsheet->disconnectWorksheets();
     }
 
-    public function emptyColumnProvider(): array
+    public static function emptyColumnProvider(): array
     {
         return [
             ['A', false],
@@ -554,7 +554,7 @@ class WorksheetTest extends TestCase
         self::assertSame($expectedData, $worksheet->toArray(null, false, false, true, true));
     }
 
-    public function toArrayHiddenRowsProvider(): array
+    public static function toArrayHiddenRowsProvider(): array
     {
         return [
             [
@@ -589,7 +589,7 @@ class WorksheetTest extends TestCase
         self::assertSame($expectedData, $worksheet->toArray(null, false, false, true, true));
     }
 
-    public function toArrayHiddenColumnsProvider(): array
+    public static function toArrayHiddenColumnsProvider(): array
     {
         return [
             [
@@ -621,7 +621,7 @@ class WorksheetTest extends TestCase
         self::assertSame($expected, $worksheet->rangeToArray($cellRange));
     }
 
-    public function rangeToArrayProvider(): array
+    public static function rangeToArrayProvider(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Writer/Html/HtmlCommentsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HtmlCommentsTest.php
@@ -13,7 +13,7 @@ class HtmlCommentsTest extends Functional\AbstractFunctional
      */
     private $spreadsheet;
 
-    public function providerCommentRichText(): array
+    public static function providerCommentRichText(): array
     {
         $valueSingle = 'I am comment.';
         $valueMulti = 'I am ' . PHP_EOL . 'multi-line' . PHP_EOL . 'comment.';

--- a/tests/PhpSpreadsheetTests/Writer/Html/HtmlNumberFormatTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/HtmlNumberFormatTest.php
@@ -182,7 +182,7 @@ class HtmlNumberFormatTest extends Functional\AbstractFunctional
         $this->writeAndReload($spreadsheet, 'Html');
     }
 
-    public function providerNumberFormat(): array
+    public static function providerNumberFormat(): array
     {
         return require __DIR__ . '/../../../data/Style/NumberFormat.php';
     }
@@ -218,7 +218,7 @@ class HtmlNumberFormatTest extends Functional\AbstractFunctional
         $this->writeAndReload($spreadsheet, 'Html');
     }
 
-    public function providerNumberFormatDates(): array
+    public static function providerNumberFormatDates(): array
     {
         return require __DIR__ . '/../../../data/Style/NumberFormatDates.php';
     }

--- a/tests/PhpSpreadsheetTests/Writer/Html/XssVulnerabilityTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Html/XssVulnerabilityTest.php
@@ -10,7 +10,7 @@ use PhpOffice\PhpSpreadsheetTests\Functional;
 
 class XssVulnerabilityTest extends Functional\AbstractFunctional
 {
-    public function providerAcceptableMarkupRichText(): array
+    public static function providerAcceptableMarkupRichText(): array
     {
         return [
             'basic text' => ['Hello, I am safely viewing your site', 'Hello, I am safely viewing your site'],
@@ -48,7 +48,7 @@ class XssVulnerabilityTest extends Functional\AbstractFunctional
         self::assertStringContainsString($adjustedTextString, $verify);
     }
 
-    public function providerXssRichText(): array
+    public static function providerXssRichText(): array
     {
         return [
             'script tag' => ["Hello, I am trying to <script>alert('Hack');</script> your site"],

--- a/tests/PhpSpreadsheetTests/Writer/PreCalcTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/PreCalcTest.php
@@ -22,7 +22,7 @@ class PreCalcTest extends AbstractFunctional
         }
     }
 
-    public function providerPreCalc(): array
+    public static function providerPreCalc(): array
     {
         return [
             [true, 'Xlsx'],

--- a/tests/PhpSpreadsheetTests/Writer/RetainSelectedCellsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/RetainSelectedCellsTest.php
@@ -7,7 +7,7 @@ use PhpOffice\PhpSpreadsheetTests\Functional\AbstractFunctional;
 
 class RetainSelectedCellsTest extends AbstractFunctional
 {
-    public function providerFormats(): array
+    public static function providerFormats(): array
     {
         return [
             ['Xls'],

--- a/tests/PhpSpreadsheetTests/Writer/Xls/VisibilityTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xls/VisibilityTest.php
@@ -27,7 +27,7 @@ class VisibilityTest extends AbstractFunctional
         }
     }
 
-    public function dataProviderRowVisibility(): array
+    public static function dataProviderRowVisibility(): array
     {
         return [
             [
@@ -55,7 +55,7 @@ class VisibilityTest extends AbstractFunctional
         }
     }
 
-    public function dataProviderColumnVisibility(): array
+    public static function dataProviderColumnVisibility(): array
     {
         return [
             [
@@ -84,7 +84,7 @@ class VisibilityTest extends AbstractFunctional
         }
     }
 
-    public function dataProviderSheetVisibility(): array
+    public static function dataProviderSheetVisibility(): array
     {
         return [
             [

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/ConditionalTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/ConditionalTest.php
@@ -120,7 +120,7 @@ class ConditionalTest extends AbstractFunctional
         self::assertStringContainsString($expected, $data);
     }
 
-    public function textConditionalsProvider(): array
+    public static function textConditionalsProvider(): array
     {
         return [
             'Contains' => [
@@ -197,7 +197,7 @@ class ConditionalTest extends AbstractFunctional
         self::assertStringContainsString($expected, $data);
     }
 
-    public function dateConditionalsProvider(): array
+    public static function dateConditionalsProvider(): array
     {
         return [
             'Yesterday' => [
@@ -325,7 +325,7 @@ class ConditionalTest extends AbstractFunctional
         self::assertStringContainsString($expected, $data);
     }
 
-    public function blanksConditionalsProvider(): array
+    public static function blanksConditionalsProvider(): array
     {
         return [
             'Blanks' => [
@@ -405,7 +405,7 @@ class ConditionalTest extends AbstractFunctional
         self::assertStringContainsString($expected, $data);
     }
 
-    public function errorsConditionalsProvider(): array
+    public static function errorsConditionalsProvider(): array
     {
         return [
             'Errors' => [
@@ -485,7 +485,7 @@ class ConditionalTest extends AbstractFunctional
         self::assertStringContainsString($expected, $data);
     }
 
-    public function duplicatesConditionalsProvider(): array
+    public static function duplicatesConditionalsProvider(): array
     {
         return [
             'Duplicates' => [
@@ -545,7 +545,7 @@ class ConditionalTest extends AbstractFunctional
         self::assertStringContainsString($expected, $data);
     }
 
-    public function expressionsConditionalsProvider(): array
+    public static function expressionsConditionalsProvider(): array
     {
         return [
             'Odd' => [

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/DrawingsTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/DrawingsTest.php
@@ -550,7 +550,7 @@ class DrawingsTest extends AbstractFunctional
         $reloadedSpreadsheet->disconnectWorksheets();
     }
 
-    public function providerEditAs(): array
+    public static function providerEditAs(): array
     {
         return [
             'absolute' => ['absolute'],

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FloatsRetainedTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FloatsRetainedTest.php
@@ -33,7 +33,7 @@ class FloatsRetainedTest extends TestCase
         $spreadsheet2->disconnectWorksheets();
     }
 
-    public function providerIntyFloatsRetainedByWriter(): array
+    public static function providerIntyFloatsRetainedByWriter(): array
     {
         return [
             [-1.0],

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/FunctionPrefixTest.php
@@ -16,7 +16,7 @@ class FunctionPrefixTest extends TestCase
         self::assertSame($expectedResult, $result);
     }
 
-    public function functionPrefixProvider(): array
+    public static function functionPrefixProvider(): array
     {
         return [
             'Basic Legacy Function' => ['SUM()', 'SUM()'],
@@ -44,7 +44,7 @@ class FunctionPrefixTest extends TestCase
 //        self::assertSame($expectedResult, $result);
 //    }
 //
-//    public function functionPrefixWithEqualsProvider(): array
+//    public static function functionPrefixWithEqualsProvider(): array
 //    {
 //        return [
 //            'Basic Legacy Function' => ['SUM()', '=SUM()'],

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue2266Test.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/Issue2266Test.php
@@ -35,7 +35,7 @@ class Issue2266Test extends AbstractFunctional
         $reloadedSpreadsheet->disconnectWorksheets();
     }
 
-    public function providerType(): array
+    public static function providerType(): array
     {
         return [
             ['Xlsx'],

--- a/tests/PhpSpreadsheetTests/Writer/Xlsx/VisibilityTest.php
+++ b/tests/PhpSpreadsheetTests/Writer/Xlsx/VisibilityTest.php
@@ -27,7 +27,7 @@ class VisibilityTest extends AbstractFunctional
         }
     }
 
-    public function dataProviderRowVisibility(): array
+    public static function dataProviderRowVisibility(): array
     {
         return [
             [
@@ -55,7 +55,7 @@ class VisibilityTest extends AbstractFunctional
         }
     }
 
-    public function dataProviderColumnVisibility(): array
+    public static function dataProviderColumnVisibility(): array
     {
         return [
             [
@@ -84,7 +84,7 @@ class VisibilityTest extends AbstractFunctional
         }
     }
 
-    public function dataProviderSheetVisibility(): array
+    public static function dataProviderSheetVisibility(): array
     {
         return [
             [


### PR DESCRIPTION
This is:

- [x] a bugfix
- [ ] a new feature
- [ ] refactoring
- [ ] additional unit tests

Checklist:

- [ ] Changes are covered by unit tests
  - [ ] Changes are covered by existing unit tests
  - [ ] New unit tests have been added
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change and a link to the pull request if applicable
- [ ] Documentation is updated as necessary

### Why this change is needed?

When there is an auto filter range defined as A1:A:100000, it forces the filter to iterate over all the rows in the range and see if needs to hide them ($this->workSheet->getRowDimension((int) $row)->setVisible($result);)

that allocates a RowDimension object for each row for each sheet, and boom, a lot of memory wasted.

This change allocates the `RowDimension` object only if the row visibility needs to be changed.
